### PR TITLE
Attach comments at or below the block's indentation level to its suffix

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -29,8 +29,8 @@ from pasta.base import ast_utils
 from pasta.base import token_generator
 
 
-def parenthesizable(f):
-  """Decorates a function where the node visited can be wrapped in parens."""
+def expression(f):
+  """Decorates a function where the node is an expression."""
   @contextlib.wraps(f)
   def wrapped(self, node, *args, **kwargs):
     with self.scope(node):
@@ -40,13 +40,27 @@ def parenthesizable(f):
   return wrapped
 
 
-def spaced(f):
-  """Decorates a function where the node visited can have space around it."""
+def statement(f):
+  """Decorates a function where the node is a statement."""
   @contextlib.wraps(f)
   def wrapped(self, node, *args, **kwargs):
     self.prefix(node)
     f(self, node, *args, **kwargs)
     self.suffix(node, oneline=True)
+  return wrapped
+
+
+def block_statement(f):
+  """Decorates a function where the node is a statement with children."""
+  @contextlib.wraps(f)
+  def wrapped(self, node, *args, **kwargs):
+    self.prefix(node)
+    f(self, node, *args, **kwargs)
+    if hasattr(self, 'block_suffix'):
+      last_child = ast_utils.get_last_child(node)
+      self.block_suffix(node, (last_child.a['prefix'].splitlines() or [''])[-1])
+    else:
+      self.suffix(node)
   return wrapped
 
 
@@ -84,15 +98,19 @@ class BaseVisitor(ast.NodeVisitor):
     """
     return ''
 
+  def ws_oneline(self):
+    """Account for up to one line of whitespace."""
+    return self.ws(oneline=True)
+
   @abc.abstractmethod
-  def token():
+  def token(self):
     """Account for a specific token."""
 
   @abc.abstractmethod
   def optional_token(node, attr_name, token_val):
     """Account for a suffix that may or may not occur."""
 
-  @spaced
+  @block_statement
   def visit_Module(self, node):
     self.generic_visit(node)
     self.attr(node, 'suffix', [self.ws])
@@ -105,11 +123,11 @@ class BaseVisitor(ast.NodeVisitor):
   def visit_Num(self, node):
     pass
 
-  @parenthesizable
+  @expression
   def visit_Expr(self, node):
     self.visit(node.value)
 
-  @parenthesizable
+  @expression
   def visit_Tuple(self, node):
     for elt in node.elts:
       self.visit(elt)
@@ -119,7 +137,7 @@ class BaseVisitor(ast.NodeVisitor):
       else:
         self.optional_token(node, 'extracomma', ',')
 
-  @parenthesizable
+  @expression
   def visit_Assign(self, node):
     for target in node.targets:
       self.visit(target)
@@ -127,7 +145,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.token('=')
     self.visit(node.value)
 
-  @parenthesizable
+  @expression
   def visit_AugAssign(self, node):
     self.visit(node.target)
     self.suffix(node.target)
@@ -135,7 +153,7 @@ class BaseVisitor(ast.NodeVisitor):
     self.token(op_token)
     self.visit(node.value)
 
-  @parenthesizable
+  @expression
   def visit_BinOp(self, node):
     self.visit(node.left)
     self.suffix(node.left)
@@ -143,7 +161,7 @@ class BaseVisitor(ast.NodeVisitor):
     self.visit(node.right)
     self.suffix(node.right)
 
-  @parenthesizable
+  @expression
   def visit_BoolOp(self, node):
     for value in node.values:
       self.visit(value)
@@ -151,28 +169,28 @@ class BaseVisitor(ast.NodeVisitor):
         self.suffix(value)
         self.visit(node.op)
 
-  @parenthesizable
+  @expression
   def visit_UnaryOp(self, node):
     self.visit(node.op)
     self.visit(node.operand)
 
-  @parenthesizable
+  @expression
   def visit_Lambda(self, node):
     self.token('lambda')
     self.visit(node.args)
     self.token(':')
     self.visit(node.body)
 
-  @spaced
+  @statement
   def visit_Import(self, node):
-    self.token('import')
-    for alias in node.names:
+    self.attr(node, 'open_import', ['import', self.ws], default='import ')
+    for i, alias in enumerate(node.names):
       self.visit(alias)
       if alias != node.names[-1]:
-        self.suffix(alias)
-        self.token(',')
+        self.attr(node, 'alias_sep_%d' % i, [self.ws, ',', self.ws],
+                  default=', ')
 
-  @spaced
+  @statement
   def visit_ImportFrom(self, node):
     self.token('from')
     self.attr(node, 'module_prefix', [self.ws], default=' ')
@@ -195,14 +213,14 @@ class BaseVisitor(ast.NodeVisitor):
       if alias != node.names[-1]:
         self.token(',')
 
-  @parenthesizable
+  @expression
   def visit_Compare(self, node):
     self.visit(node.left)
     for op, comparator in zip(node.ops, node.comparators):
       self.visit(op)
       self.visit(comparator)
 
-  @spaced
+  @statement
   def visit_Ellipsis(self, node):
     self.token('...')
 
@@ -260,47 +278,47 @@ class BaseVisitor(ast.NodeVisitor):
   def visit_Or(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_Eq(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_NotEq(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_Lt(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_LtE(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_Gt(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_GtE(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_Is(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_IsNot(self, node):
     self.attr(node, 'content', ['is', self.ws, 'not'], default='is not')
 
-  @spaced
+  @statement
   def visit_In(self, node):
     self.token(ast_constants.NODE_TYPE_TO_TOKENS[type(node)][0])
 
-  @spaced
+  @statement
   def visit_NotIn(self, node):
     self.attr(node, 'content', ['not', self.ws, 'in'], default='not in')
 
-  @spaced
+  @statement
   def visit_alias(self, node):
     name_pattern = []
     parts = node.name.split('.')
@@ -314,11 +332,12 @@ class BaseVisitor(ast.NodeVisitor):
       self.attr(node, 'asname', [self.ws, 'as', self.ws], default=' as ')
       self.token(node.asname)
 
-  @spaced
+  @block_statement
   def visit_If(self, node):
     self.token('elif' if ast_utils.prop(node, 'is_elif') else 'if')
     self.visit(node.test)
-    self.attr(node, 'testsuffix', [self.ws, ':', self.ws], default=':')
+    self.attr(node, 'testsuffix', [self.ws, ':', self.ws_oneline],
+              default=':')
     for stmt in node.body:
       self.visit(stmt)
 
@@ -330,7 +349,8 @@ class BaseVisitor(ast.NodeVisitor):
       else:
         self.attr(node, 'elseprefix', [self.ws])
         self.token('else')
-        self.attr(node, 'elsesuffix', [self.ws, ':', self.ws], default=':')
+        self.attr(node, 'elsesuffix', [self.ws, ':', self.ws_oneline],
+                  default=':')
         for stmt in node.orelse:
           self.visit(stmt)
 
@@ -355,7 +375,7 @@ class BaseVisitor(ast.NodeVisitor):
     This method should return True for the 'if b' node if it has the first form.
     """
 
-  @parenthesizable
+  @expression
   def visit_IfExp(self, node):
     self.visit(node.body)
     self.suffix(node.body)
@@ -365,22 +385,23 @@ class BaseVisitor(ast.NodeVisitor):
     self.token('else')
     self.visit(node.orelse)
 
-  @spaced
+  @block_statement
   def visit_While(self, node):
     self.token('while')
     self.visit(node.test)
-    self.attr(node, 'testsuffix', [self.ws, ':', self.ws], default=':')
+    self.attr(node, 'testsuffix', [self.ws, ':', self.ws_oneline], default=':')
     for stmt in node.body:
       self.visit(stmt)
 
     if node.orelse:
       self.attr(node, 'elseprefix', [self.ws])
       self.token('else')
-      self.attr(node, 'elsesuffix', [self.ws, ':', self.ws], default=':')
+      self.attr(node, 'elsesuffix', [self.ws, ':', self.ws_oneline],
+                default=':')
       for stmt in node.orelse:
         self.visit(stmt)
 
-  @spaced
+  @block_statement
   def visit_For(self, node):
     self.token('for')
     self.visit(node.target)
@@ -400,24 +421,22 @@ class BaseVisitor(ast.NodeVisitor):
       for stmt in node.orelse:
         self.visit(stmt)
 
-  @spaced
+  @statement
   def visit_Repr(self, node):
     self.attr(node, 'repr_open', ['repr', self.ws, '('], default='repr(')
     self.visit(node.value)
     self.attr(node, 'repr_close', [self.ws, ')'], default=')')
 
-  @spaced
+  @block_statement
   def visit_With(self, node):
     if hasattr(node, 'items'):
       return self.visit_With_3(node)
     if not getattr(node, 'is_continued', False):
       self.token('with')
     self.visit(node.context_expr)
-    self.suffix(node.context_expr)
     if node.optional_vars:
       self.token('as')
       self.visit(node.optional_vars)
-      self.suffix(node.optional_vars)
 
     if self.check_is_continued_with(node.body[0]):
       node.body[0].is_continued = True
@@ -447,7 +466,6 @@ class BaseVisitor(ast.NodeVisitor):
     This method should return True for the `with b` and `with c` nodes.
     """
 
-  @spaced
   def visit_With_3(self, node):
     self.token('with')
 
@@ -456,11 +474,11 @@ class BaseVisitor(ast.NodeVisitor):
       if i != len(node.items) - 1:
         self.token(',')
 
-    self.token(':')
+    self.attr(node, 'with_body_open', [':', self.ws_oneline], default=':\n')
     for stmt in node.body:
       self.visit(stmt)
 
-  @spaced
+  @statement
   def visit_withitem(self, node):
     self.visit(node.context_expr)
     self.suffix(node.context_expr)
@@ -469,7 +487,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.visit(node.optional_vars)
       self.suffix(node.optional_vars)
 
-  @spaced
+  @statement
   def visit_Assert(self, node):
     self.token('assert')
     self.visit(node.test)
@@ -477,7 +495,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.token(',')
       self.visit(node.msg)
 
-  @spaced
+  @statement
   def visit_Exec(self, node):
     self.attr(node, 'exec', ['exec', self.ws], default='exec ')
     self.visit(node.body)
@@ -488,7 +506,7 @@ class BaseVisitor(ast.NodeVisitor):
         self.attr(node, 'in_locals', [self.ws, ',', self.ws], default=', ')
         self.visit(node.locals)
 
-  @spaced
+  @statement
   def visit_Global(self, node):
     self.token('global')
     identifiers = []
@@ -498,7 +516,7 @@ class BaseVisitor(ast.NodeVisitor):
       identifiers.extend([self.ws, ident])
     self.attr(node, 'names', identifiers)
 
-  @spaced
+  @statement
   def visit_Nonlocal(self, node):
     self.token('nonlocal')
     identifiers = []
@@ -508,32 +526,32 @@ class BaseVisitor(ast.NodeVisitor):
       identifiers.extend([self.ws, ident])
     self.attr(node, 'names', identifiers)
 
-  @parenthesizable
+  @expression
   def visit_Name(self, node):
     self.token(node.id)
 
-  @parenthesizable
+  @expression
   def visit_NameConstant(self, node):
     self.token(str(node.value))
 
-  @parenthesizable
+  @expression
   def visit_Attribute(self, node):
     self.visit(node.value)
     self.attr(node, 'dot', [self.ws, '.', self.ws], default='.')
     self.token(node.attr)
 
-  @parenthesizable
+  @expression
   def visit_Subscript(self, node):
     self.visit(node.value)
     self.visit(node.slice)
 
-  @spaced
+  @statement
   def visit_Index(self, node):
     self.attr(node, 'index_open', ['[', self.ws], default='[')
     self.visit(node.value)
     self.attr(node, 'index_close', [self.ws, ']'], default=']')
 
-  @spaced
+  @statement
   def visit_Slice(self, node):
     self.token('[')
 
@@ -560,7 +578,7 @@ class BaseVisitor(ast.NodeVisitor):
 
     self.token(']')
 
-  @parenthesizable
+  @expression
   def visit_List(self, node):
     self.attr(node, 'list_open', ['[', self.ws], default='[')
 
@@ -574,7 +592,7 @@ class BaseVisitor(ast.NodeVisitor):
 
     self.attr(node, 'list_close', [self.ws, ']'], default=']')
 
-  @parenthesizable
+  @expression
   def visit_Set(self, node):
     self.token('{')
 
@@ -588,7 +606,7 @@ class BaseVisitor(ast.NodeVisitor):
 
     self.token('}')
 
-  @parenthesizable
+  @expression
   def visit_Dict(self, node):
     self.token('{')
 
@@ -604,15 +622,15 @@ class BaseVisitor(ast.NodeVisitor):
     self.attr(node, 'close_prefix', [self.ws])
     self.token('}')
 
-  @parenthesizable
+  @expression
   def visit_GeneratorExp(self, node):
     self._comp_exp(node)
 
-  @parenthesizable
+  @expression
   def visit_ListComp(self, node):
     self._comp_exp(node, open_brace='[', close_brace=']')
 
-  @parenthesizable
+  @expression
   def visit_SetComp(self, node):
     self._comp_exp(node, open_brace='{', close_brace='}')
 
@@ -628,7 +646,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.attr(node, 'compexp_close', [self.ws, close_brace],
                 default=close_brace)
 
-  @parenthesizable
+  @expression
   def visit_DictComp(self, node):
     self.token('{')
     self.visit(node.key)
@@ -641,7 +659,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.visit(comp)
     self.token('}')
 
-  @spaced
+  @statement
   def visit_comprehension(self, node):
     self.visit(node.target)
     self.suffix(node.target)
@@ -654,7 +672,7 @@ class BaseVisitor(ast.NodeVisitor):
       if if_expr != node.ifs[-1]:
         self.suffix(if_expr)
 
-  @parenthesizable
+  @expression
   def visit_Call(self, node):
     self.visit(node.func)
     self.suffix(node.func)
@@ -697,7 +715,7 @@ class BaseVisitor(ast.NodeVisitor):
 
     self.token(')')
 
-  @spaced
+  @statement
   def visit_arguments(self, node):
     total_args = (len(node.args) +
                   (1 if node.vararg else 0) +
@@ -746,7 +764,7 @@ class BaseVisitor(ast.NodeVisitor):
     if positional or keyword or node.vararg or node.kwarg:
       self.optional_token(node, 'extracomma', ',')
 
-  @spaced
+  @statement
   def visit_arg(self, node):
     self.token(node.arg)
     self.suffix(node)
@@ -754,7 +772,7 @@ class BaseVisitor(ast.NodeVisitor):
       self.token(':')
       self.visit(node.annotation)
 
-  @spaced
+  @block_statement
   def visit_FunctionDef(self, node):
     for decorator in node.decorator_list:
       self.token('@')
@@ -778,25 +796,25 @@ class BaseVisitor(ast.NodeVisitor):
     for expr in node.body:
       self.visit(expr)
 
-  @spaced
+  @statement
   def visit_keyword(self, node):
     self.token(node.arg)
     self.attr(node, 'eq', [self.ws, '='], default='=')
     self.visit(node.value)
 
-  @spaced
+  @statement
   def visit_Return(self, node):
     self.token('return')
     if node.value:
       self.visit(node.value)
 
-  @spaced
+  @statement
   def visit_Yield(self, node):
     self.token('yield')
     if node.value:
       self.visit(node.value)
 
-  @spaced
+  @statement
   def visit_Delete(self, node):
     self.token('del')
     for target in node.targets:
@@ -805,7 +823,7 @@ class BaseVisitor(ast.NodeVisitor):
       if target != node.targets[-1]:
         self.token(',')
 
-  @spaced
+  @statement
   def visit_Print(self, node):
     self.token('print')
     self.attr(node, 'print_suffix', [self.ws], default=' ')
@@ -822,7 +840,7 @@ class BaseVisitor(ast.NodeVisitor):
         self.suffix(value)
         self.token(',')
 
-  @spaced
+  @block_statement
   def visit_ClassDef(self, node):
     for decorator in node.decorator_list:
       self.token('@')
@@ -851,44 +869,47 @@ class BaseVisitor(ast.NodeVisitor):
     for expr in node.body:
       self.visit(expr)
 
-  @spaced
+  @statement
   def visit_Pass(self, node):
     self.token('pass')
 
-  @spaced
+  @statement
   def visit_Break(self, node):
     self.token('break')
 
-  @spaced
+  @statement
   def visit_Continue(self, node):
     self.token('continue')
 
-  @spaced
+  @block_statement
   def visit_TryFinally(self, node):
     # Try with except and finally is a TryFinally with the first statement as a
     # TryExcept in Python2
     if not isinstance(node.body[0], ast.TryExcept):
-      self.attr(node, 'open_try', ['try', self.ws, ':'], default='try:')
+      self.attr(node, 'open_try', ['try', self.ws, ':', self.ws_oneline],
+                default='try:')
     for stmt in node.body:
       self.visit(stmt)
-    self.attr(node, 'open_finally', ['finally', self.ws, ':'],
+    self.attr(node, 'open_finally', ['finally', self.ws, ':', self.ws_oneline],
               default='finally:')
     for stmt in node.finalbody:
       self.visit(stmt)
 
-  @spaced
+  @block_statement
   def visit_TryExcept(self, node):
-    self.attr(node, 'open_try', ['try', self.ws, ':'], default='try:')
+    self.attr(node, 'open_try', ['try', self.ws, ':', self.ws_oneline],
+              default='try:')
     for stmt in node.body:
       self.visit(stmt)
     for handler in node.handlers:
       self.visit(handler)
     if node.orelse:
-      self.attr(node, 'open_else', ['else', self.ws, ':'], default='else:')
+      self.attr(node, 'open_else', ['else', self.ws, ':', self.ws_oneline],
+                default='else:')
       for stmt in node.orelse:
         self.visit(stmt)
 
-  @spaced
+  @block_statement
   def visit_Try(self, node):
     # Python 3
     self.attr(node, 'open_try', ['try', self.ws, ':'], default='try:')
@@ -906,7 +927,7 @@ class BaseVisitor(ast.NodeVisitor):
       for stmt in node.finalbody:
         self.visit(stmt)
 
-  @spaced
+  @block_statement
   def visit_ExceptHandler(self, node):
     self.token('except')
     if node.type:
@@ -919,12 +940,11 @@ class BaseVisitor(ast.NodeVisitor):
         self.visit(node.name)
       else:
         self.token(node.name)
-        self.attr(node, 'name_suffix', [self.ws])
-    self.token(':')
+    self.attr(node, 'open_except', [self.ws, ':', self.ws_oneline], default=':')
     for stmt in node.body:
       self.visit(stmt)
 
-  @spaced
+  @statement
   def visit_Raise(self, node):
     self.token('raise')
     if node.type:
@@ -959,7 +979,7 @@ class AstAnnotator(BaseVisitor):
     except (TypeError, ValueError, IndexError, KeyError) as e:
       raise AnnotationError(e)
 
-  @parenthesizable
+  @expression
   def visit_Num(self, node):
     """Annotate a Num node with the exact number format."""
     token_number_type = token_generator.TOKENS.NUMBER
@@ -968,7 +988,7 @@ class AstAnnotator(BaseVisitor):
       contentargs.insert(0, '-')
     self.attr(node, 'content', contentargs, deps=('n',), default=str(node.n))
 
-  @parenthesizable
+  @expression
   def visit_Str(self, node):
     """Annotate a Str node with the exact string format."""
     self.attr(node, 'content', [self.tokens.str], deps=('s',), default=node.s)
@@ -985,6 +1005,9 @@ class AstAnnotator(BaseVisitor):
   def ws(self, oneline=False):
     """Parse some whitespace from the source tokens and return it."""
     return self.tokens.whitespace(oneline=oneline)
+
+  def block_suffix(self, node, indent_level):
+    ast_utils.setprop(node, 'suffix', self.tokens.block_whitespace(indent_level))
 
   def token(self, token_val):
     """Parse a single token with exactly the given value."""
@@ -1056,7 +1079,7 @@ class AstAnnotator(BaseVisitor):
 
   def _optional_token(self, token_type, token_val):
     token = self.tokens.peek()
-    if token[0] != token_type or token[1] != token_val:
+    if not token or token[0] != token_type or token[1] != token_val:
       return ''
     else:
       self.tokens.next()

--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -58,7 +58,10 @@ def block_statement(f):
     f(self, node, *args, **kwargs)
     if hasattr(self, 'block_suffix'):
       last_child = ast_utils.get_last_child(node)
-      self.block_suffix(node, (last_child.a['prefix'].splitlines() or [''])[-1])
+      # Workaround for ast.Module which does not have a lineno
+      if last_child.lineno != getattr(node, 'lineno', 0):
+        indent = (ast_utils.prop(last_child, 'prefix') or '\n').splitlines()[-1]
+        self.block_suffix(node, indent)
     else:
       self.suffix(node)
   return wrapped

--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import ast
 import difflib
 import os.path
+import textwrap
 import unittest
 
 import pasta
@@ -34,7 +35,56 @@ TESTDATA_DIR = os.path.realpath(
 
 
 class SymmetricTest(test_utils.TestCase):
-  pass
+
+  def test_block_suffix(self):
+    src_tpl = textwrap.dedent('''\
+        {open_block}
+          pass #a
+          #b
+            #c
+
+          #d
+        #e
+        a
+        ''')
+    test_cases = (
+        'def x():',
+        'class X:',
+        'if x:',
+        'if x:\n  y\nelse:',
+        'if x:\n  y\nelif y:',
+        'while x:',
+        'while x:\n  y\nelse:',
+        'try:\n  x\nfinally:',
+        'try:\n  x\nexcept:',
+        'try:\n  x\nexcept:\n  y\nelse:',
+        'with x:',
+        'with x, y:',
+        'with x:\n with y:',
+        'for x in y:',
+    )
+    def is_node_for_suffix(node):
+      # Return True if this node contains the 'pass' statement
+      for attr in dir(node):
+        attr_val = getattr(node, attr)
+        if (isinstance(attr_val, list) and
+            any(isinstance(child, ast.Pass) for child in attr_val)):
+          return True
+      return False
+    node_finder = ast_utils.FindNodeVisitor(is_node_for_suffix)
+
+    for open_block in test_cases:
+      src = src_tpl.format(open_block=open_block)
+      t = pasta.parse(src)
+      node_finder.results = []
+      node_finder.visit(t)
+      node = node_finder.results[0]
+      expected = '  #b\n    #c\n\n  #d\n'
+      actual = ast_utils.prop(node, 'suffix')
+      self.assertMultiLineEqual(
+          expected, actual,
+          'Incorrect suffix for code:\n%s\nNode: %s (line %d)\nDiff:\n%s' % (
+              src, node, node.lineno, '\n'.join(get_diff(actual, expected))))
 
 
 def symmetric_test_generator(filepath):

--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -86,6 +86,11 @@ class SymmetricTest(test_utils.TestCase):
           'Incorrect suffix for code:\n%s\nNode: %s (line %d)\nDiff:\n%s' % (
               src, node, node.lineno, '\n'.join(get_diff(actual, expected))))
 
+  def test_no_block_suffix_for_single_line_statement(self):
+    src = 'if x:  return y\n  #a\n#b\n'
+    t = pasta.parse(src)
+    self.assertEqual('', ast_utils.prop(t.body[0], 'suffix'))
+
 
 def symmetric_test_generator(filepath):
   def test(self):

--- a/pasta/base/ast_utils.py
+++ b/pasta/base/ast_utils.py
@@ -137,3 +137,30 @@ class FindNodeVisitor(ast.NodeVisitor):
     if self._condition(node):
       self.results.append(node)
     super(FindNodeVisitor, self).visit(node)
+
+
+def get_last_child(node):
+  if isinstance(node, ast.If):
+    if (len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If) and
+        prop(node.orelse[0], 'is_elif')):
+      return get_last_child(node.orelse[0])
+    if node.orelse:
+      return node.orelse[-1]
+  elif isinstance(node, ast.With):
+    if (len(node.body) == 1 and isinstance(node.body[0], ast.With) and
+        prop(node.body[0], 'is_continued')):
+      return get_last_child(node.body[0])
+  elif hasattr(ast, 'Try') and isinstance(node, ast.Try):
+    if node.finalbody:
+      return node.finalbody[-1]
+    if node.orelse:
+      return node.orelse[-1]
+  elif hasattr(ast, 'TryFinally') and isinstance(node, ast.TryFinally):
+    if node.finalbody:
+      return node.finalbody[-1]
+  elif hasattr(ast, 'TryExcept') and isinstance(node, ast.TryExcept):
+    if node.orelse:
+      return node.orelse[-1]
+    if node.handlers:
+      return get_last_child(node.handlers[-1])
+  return node.body[-1]

--- a/pasta/base/ast_utils.py
+++ b/pasta/base/ast_utils.py
@@ -140,6 +140,24 @@ class FindNodeVisitor(ast.NodeVisitor):
 
 
 def get_last_child(node):
+  """Get the last child node of a block statement.
+
+  The input must be a block statement (e.g. ast.For, ast.With, etc).
+
+  Examples:
+    1. with first():
+         second()
+         last()
+
+    2. try:
+         first()
+       except:
+         second()
+       finally:
+         last()
+
+  In both cases, the last child is the node for `last`.
+  """
   if isinstance(node, ast.If):
     if (len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If) and
         prop(node.orelse[0], 'is_elif')):

--- a/pasta/base/test_utils.py
+++ b/pasta/base/test_utils.py
@@ -26,13 +26,6 @@ class TestCase(unittest.TestCase):
   pass
 
 
-if not hasattr(TestCase, 'assertMultiLineEqual'):
-  def assertMultiLineEqual(self, before, after):
-    self.assertEqual(before, after, 'Output does not match expected\n' +
-                     '\n'.join(get_diff(before, after)))
-  setattr(TestCase, 'assertMultiLineEqual', assertMultiLineEqual)
-
-
 if not hasattr(TestCase, 'assertItemsEqual'):
   setattr(TestCase, 'assertItemsEqual', TestCase.assertCountEqual)
 

--- a/pasta/base/token_generator.py
+++ b/pasta/base/token_generator.py
@@ -113,11 +113,11 @@ class TokenGenerator(object):
     """Parses whitespace from the current _loc to the end of the block."""
     # Get the normal suffix lines, but don't advance the token index unless
     # there is no indentation to account for
-    starti = self._i
+    start_i = self._i
     full_whitespace = self.whitespace()
     if not indent_level:
       return full_whitespace
-    self._i = starti
+    self._i = start_i
 
     # Trim the full whitespace into only lines that match the indentation level
     lines = full_whitespace.splitlines(True)

--- a/pasta/base/token_generator.py
+++ b/pasta/base/token_generator.py
@@ -45,7 +45,6 @@ class TokenGenerator(object):
     self._lines = source.splitlines(True)
     self._len = len(self._tokens)
     self._i = -1
-    self._eaten = -1
     self._loc = self.loc_begin()
 
   def loc_begin(self):
@@ -62,7 +61,7 @@ class TokenGenerator(object):
 
   def peek(self):
     """Get the next token without advancing."""
-    if self._i >= self._len:
+    if self._i + 1 >= self._len:
       return None
     return self._tokens[self._i + 1]
 
@@ -95,7 +94,8 @@ class TokenGenerator(object):
     next_token = self.peek()
 
     result = ''
-    for tok in itertools.chain(whitespace, (next_token,)):
+    for tok in itertools.chain(whitespace,
+                               ((next_token,) if next_token else ())):
       result += self._space_between(self._loc, tok)
       if tok != next_token:
         result += tok[1]
@@ -104,10 +104,37 @@ class TokenGenerator(object):
         self._loc = tok[2]
 
     # Eat a single newline character
-    if next_token[0] in (TOKENS.NL, TOKENS.NEWLINE):
+    if next_token and next_token[0] in (TOKENS.NL, TOKENS.NEWLINE):
       result += self.next()[1]
 
     return result
+
+  def block_whitespace(self, indent_level):
+    """Parses whitespace from the current _loc to the end of the block."""
+    # Get the normal suffix lines, but don't advance the token index unless
+    # there is no indentation to account for
+    starti = self._i
+    full_whitespace = self.whitespace()
+    if not indent_level:
+      return full_whitespace
+    self._i = starti
+
+    # Trim the full whitespace into only lines that match the indentation level
+    lines = full_whitespace.splitlines(True)
+    try:
+      last_line_idx = next(i for i, line in reversed(list(enumerate(lines)))
+                           if line.startswith(indent_level + '#'))
+    except StopIteration:
+      # No comment lines at the end of this block
+      self._loc = self._tokens[self._i][3]
+      return ''
+    lines = lines[:last_line_idx + 1]
+
+    # Advance the current location to the last token in the lines we've read
+    end_line = self._tokens[self._i][3][0] + 1 + len(lines)
+    list(self.takewhile(lambda tok: tok[2][0] < end_line))
+    self._loc = self._tokens[self._i][3]
+    return ''.join(lines)
 
   def open_scope(self, node):
     """Open a parenthesized scope on the given node."""


### PR DESCRIPTION
Fixes #3.

For block statements (any statement with a body) count everything from the indentation level of the last child to the next node as part of its suffix.

For example:
```python
def foo():
  bar()
  #a
  #b

#c
```

The suffix on `FunctionDef` node `foo` is `#a\n  #b\n` and the suffix on the `Module` node (or prefix on the next node, if there is one) is `\n\n#c\n`. See `annotate_test` for a more detailed example.