### PR TITLE
Fix suffix lines on expressions

### DIFF
--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -91,6 +91,18 @@ class SymmetricTest(test_utils.TestCase):
     t = pasta.parse(src)
     self.assertEqual('', ast_utils.prop(t.body[0], 'suffix'))
 
+  def test_expression_prefix_suffix(self):
+    src = 'a\n\nfoo\n\n\nb\n'
+    t = pasta.parse(src)
+    self.assertEqual('\n', ast_utils.prop(t.body[1], 'prefix'))
+    self.assertEqual('\n', ast_utils.prop(t.body[1], 'suffix'))
+
+  def test_statement_prefix_suffix(self):
+    src = 'a\n\ndef foo():\n  return bar\n\n\nb\n'
+    t = pasta.parse(src)
+    self.assertEqual('\n', ast_utils.prop(t.body[1], 'prefix'))
+    self.assertEqual('', ast_utils.prop(t.body[1], 'suffix'))
+
 
 def symmetric_test_generator(filepath):
   def test(self):

--- a/pasta/base/token_generator.py
+++ b/pasta/base/token_generator.py
@@ -80,8 +80,12 @@ class TokenGenerator(object):
     """Rewind the token iterator."""
     self._i -= amount
 
-  def whitespace(self, oneline=False):
+  def whitespace(self, max_lines=None):
     """Parses whitespace from the current _loc to the next non-whitespace.
+
+    Arguments:
+      max_lines: (optional int) Maximum number of lines to consider as part of
+        the whitespace. Valid values are None, 0 and 1.
 
     Pre-condition:
       `_loc' represents the point before which everything has been parsed and
@@ -91,7 +95,7 @@ class TokenGenerator(object):
     """
     def predicate(token):
       return (token.type in (TOKENS.COMMENT, TOKENS.INDENT, TOKENS.DEDENT) or
-              not oneline and token.type in (TOKENS.NL, TOKENS.NEWLINE))
+              max_lines is None and token.type in (TOKENS.NL, TOKENS.NEWLINE))
     whitespace = list(self.takewhile(predicate, advance=False))
     next_token = self.peek()
 
@@ -106,7 +110,8 @@ class TokenGenerator(object):
         self._loc = tok.start
 
     # Eat a single newline character
-    if next_token and next_token.type in (TOKENS.NL, TOKENS.NEWLINE):
+    if ((max_lines is None or max_lines > 0) and
+        next_token and next_token.type in (TOKENS.NL, TOKENS.NEWLINE)):
       result += self.next().src
 
     return result


### PR DESCRIPTION
Expressions (e.g, a Str value) are values contained in a statement (or
another expression) and should leave the suffix newlines for the
statement to parse.

This includes a fix for Assign / AugAssign / Expr nodes which were
incorrectly being treated as expressions, but are actually statements.