### PR TITLE
Strip 'coding' declaration before parsing source code

### DIFF
--- a/pasta/base/ast_utils.py
+++ b/pasta/base/ast_utils.py
@@ -21,8 +21,12 @@ from __future__ import print_function
 import ast
 import collections
 import itertools
+import re
 
 from pasta.augment import errors
+
+# From PEP-0263 -- https://www.python.org/dev/peps/pep-0263/
+_CODING_PATTERN = re.compile('^[ \t\v]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)')
 
 
 def find_starargs(call_node):
@@ -69,7 +73,19 @@ def normalize(tree):
 
 
 def parse(src):
-  return normalize(ast.parse(src))
+  return normalize(ast.parse(sanitize_source(src)))
+
+
+def sanitize_source(src):
+  """Strip the 'coding' directive from python source code, if present.
+
+  This is a workaround for https://bugs.python.org/issue18960. Also see PEP-0263.
+  """
+  src_lines = src.splitlines(True)
+  for i, line in enumerate(src_lines[:2]):
+    if _CODING_PATTERN.match(line):
+      src_lines[i] = re.sub('#.*$', '# (removed coding)', line)
+  return ''.join(src_lines)
 
 
 def space_between(from_loc, to_loc, line, lines):

--- a/pasta/base/ast_utils_test.py
+++ b/pasta/base/ast_utils_test.py
@@ -28,6 +28,32 @@ from pasta.base import test_utils
 from pasta.base import scope
 
 
+class UtilsTest(test_utils.TestCase):
+
+  def test_sanitize_source(self):
+    coding_lines = (
+        '# -*- coding: latin-1 -*-',
+        '# -*- coding: iso-8859-15 -*-',
+        '# vim: set fileencoding=ascii :',
+        '# This Python file uses the following encoding: utf-8',
+    )
+    src_template = '{coding}\na = 123\n'
+    sanitized_src = '# (removed coding)\na = 123\n'
+    for line in coding_lines:
+      src = src_template.format(coding=line)
+
+      # Replaced on lines 1 and 2
+      self.assertEqual(sanitized_src, ast_utils.sanitize_source(src))
+      src_prefix = '"""Docstring."""\n'
+      self.assertEqual(src_prefix + sanitized_src,
+                       ast_utils.sanitize_source(src_prefix + src))
+
+      # Unchanged on line 3
+      src_prefix = '"""Docstring."""\n# line 2\n'
+      self.assertEqual(src_prefix + src,
+                       ast_utils.sanitize_source(src_prefix + src))
+
+
 class RemoveChildTest(test_utils.TestCase):
 
   # TODO(soupytwist): enable this when the unrelated formatting bug that is


### PR DESCRIPTION
Workaround for https://bugs.python.org/issue18960