### PR TITLE
Fix formatting bug + turn on disabled test

### DIFF
--- a/pasta/base/ast_utils_test.py
+++ b/pasta/base/ast_utils_test.py
@@ -30,9 +30,7 @@ from pasta.base import scope
 
 class RemoveChildTest(test_utils.TestCase):
 
-  # TODO(soupytwist): enable this when the unrelated formatting bug that is
-  # breaking it is fixed.
-  def disabled_testRemoveChildMethod(self):
+  def testRemoveChildMethod(self):
     src = """\
 class C():
   def f(x):


### PR DESCRIPTION
The main issue is in line 165 on `annotate.py` with the extra suffix being put on the right operand of a `BinOp`, even though it is an expression (no newlines after).