### PR TITLE
Store indentation level + diff on each statement node

### DIFF
--- a/pasta/base/ast_utils.py
+++ b/pasta/base/ast_utils.py
@@ -121,15 +121,16 @@ def space_between(from_loc, to_loc, line, lines):
 def setup_props(node):
   if not hasattr(node, PASTA_DICT):
     try:
-      setattr(node, PASTA_DICT, collections.defaultdict(lambda: ''))
+      setattr(node, PASTA_DICT, collections.defaultdict(lambda: None))
     except AttributeError:
       pass
 
 
 def prop(node, name):
-  if hasattr(node, PASTA_DICT):
+  try:
     return getattr(node, PASTA_DICT)[name]
-  return None
+  except AttributeError:
+    return None
 
 
 def setprop(node, name, value):
@@ -138,11 +139,13 @@ def setprop(node, name, value):
 
 
 def appendprop(node, name, value):
-  getattr(node, PASTA_DICT)[name] += value
+  pasta_dict = getattr(node, PASTA_DICT)
+  pasta_dict[name] = pasta_dict.get(name, '') + value
 
 
 def prependprop(node, name, value):
-  getattr(node, PASTA_DICT)[name] = value + getattr(node, PASTA_DICT)[name]
+  pasta_dict = getattr(node, PASTA_DICT)
+  pasta_dict[name] = value + pasta_dict.get(name, '')
 
 
 def find_nodes_by_type(node, accept_types):

--- a/pasta/base/codegen.py
+++ b/pasta/base/codegen.py
@@ -43,6 +43,7 @@ class Printer(annotate.BaseVisitor):
   def __init__(self):
     super(Printer, self).__init__()
     self.code = ''
+    self._indent = ''
 
   def visit(self, node):
     node._printer_info = collections.defaultdict(lambda: False)
@@ -72,7 +73,7 @@ class Printer(annotate.BaseVisitor):
     del token_val, allow_whitespace_prefix
     if not hasattr(node, ast_utils.PASTA_DICT):
       return
-    self.code += ast_utils.prop(node, attr_name)
+    self.code += ast_utils.prop(node, attr_name) or ''
 
   def attr(self, node, attr_name, attr_vals, deps=None, default=None):
     """Add the formatted data stored for a given attribute on this node.
@@ -93,13 +94,12 @@ class Printer(annotate.BaseVisitor):
     if not hasattr(node, '_printer_info') or node._printer_info[attr_name]:
       return
     node._printer_info[attr_name] = True
-    if (deps and
+    val = ast_utils.prop(node, attr_name)
+    if (val is None or deps and
         any(getattr(node, dep, None) != ast_utils.prop(node, dep + '__src')
             for dep in deps)):
-      self.code += default or ''
-    else:
-      val = ast_utils.prop(node, attr_name)
-      self.code += val if val is not None else (default or '')
+      val = default
+    self.code += val if val is not None else ''
 
   def check_is_elif(self, node):
     try:

--- a/pasta/base/token_generator.py
+++ b/pasta/base/token_generator.py
@@ -54,12 +54,12 @@ class TokenGenerator(object):
   """
 
   def __init__(self, source):
+    self.lines = source.splitlines(True)
     _token_generator = tokenize.generate_tokens(StringIO(source).readline)
     self._tokens = list(Token(*tok) for tok in _token_generator)
     self._parens = []
     self._hints = 0
     self._scope_stack = []
-    self._lines = source.splitlines(True)
     self._len = len(self._tokens)
     self._i = -1
     self._loc = self.loc_begin()
@@ -291,10 +291,10 @@ class TokenGenerator(object):
     """Parse the space between a location and the next token"""
     if prev_loc > tok.start:
       raise ValueError('prev_loc > token start', prev_loc, tok.start)
-    if prev_loc[0] > len(self._lines):
+    if prev_loc[0] > len(self.lines):
       return ''
     return ast_utils.space_between(prev_loc, tok.start,
-                                   self._lines[prev_loc[0] - 1], self._lines)
+                                   self.lines[prev_loc[0] - 1], self.lines)
 
   def next_name(self):
     """Parse the next name token."""
@@ -313,7 +313,7 @@ class TokenGenerator(object):
     if token.type != token_type:
       raise ValueError("Expected %r but found %r\nline %d: %s" % (
           tokenize.tok_name[token_type], token.src, token.start[0],
-          self._lines[token.start[0] - 1]))
+          self.lines[token.start[0] - 1]))
     return token
 
   def takewhile(self, condition, advance=True):

--- a/testdata/ast/golden/2.7/assert.out
+++ b/testdata/ast/golden/2.7/assert.out
@@ -1,12 +1,12 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Assert               	prefix=||	suffix=|\n|
-(3, 0)       Assert               	prefix=|\n|	suffix=|\n|
-(5, 0)       Assert               	prefix=|\n|	suffix=|\n|
-(1, 7)       Name a               	prefix=| |	suffix=||
-(3, 8)       Name b               	prefix=| (|	suffix=|)|
-(5, 9)       Name c               	prefix=|   |	suffix=|  |
-(5, 15)      Name d               	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Assert               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Assert               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Assert               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 7)       Name a               	prefix=| |	suffix=||	indent=||
+(3, 8)       Name b               	prefix=| (|	suffix=|)|	indent=||
+(5, 9)       Name c               	prefix=|   |	suffix=|  |	indent=||
+(5, 15)      Name d               	prefix=|  |	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/assign.out
+++ b/testdata/ast/golden/2.7/assign.out
@@ -1,20 +1,20 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Assign               	prefix=||	suffix=|\n|
-(3, 0)       Assign               	prefix=|\n|	suffix=|\n|
-(5, 0)       Assign               	prefix=|\n|	suffix=|\n|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=| |
-(3, 9)       Name e               	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=||
-(5, 2)       Name g               	prefix=||	suffix=|  |
-(5, 8)       Name h               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Assign               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Assign               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Assign               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=| |	indent=||
+(3, 9)       Name e               	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=||	indent=||
+(5, 2)       Name g               	prefix=||	suffix=|  |	indent=||
+(5, 8)       Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/attribute.out
+++ b/testdata/ast/golden/2.7/attribute.out
@@ -1,16 +1,16 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Attribute b          	prefix=||	suffix=||
-(3, 0)       Attribute d          	prefix=||	suffix=||
-(5, 2)       Attribute f          	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name e               	prefix=|( |	suffix=| )|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Attribute b          	prefix=||	suffix=||	indent=||
+(3, 0)       Attribute d          	prefix=||	suffix=||	indent=||
+(5, 2)       Attribute f          	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name e               	prefix=|( |	suffix=| )|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/augassign.out
+++ b/testdata/ast/golden/2.7/augassign.out
@@ -1,20 +1,20 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       AugAssign            	prefix=||	suffix=|\n|
-(3, 0)       AugAssign            	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=||
-(1, 5)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(-1, -1)     Sub                  	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=||
-(5, 0)       Compare              	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=|   |
-(-1, -1)     LtE                  	prefix=||	suffix=|  |
-(5, 8)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       AugAssign            	prefix=||	suffix=|\n|	indent=||
+(3, 0)       AugAssign            	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=||	indent=||
+(1, 5)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Sub                  	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Compare              	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     LtE                  	prefix=||	suffix=|  |	indent=||
+(5, 8)       Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/binop.out
+++ b/testdata/ast/golden/2.7/binop.out
@@ -1,71 +1,71 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       BinOp                	prefix=||	suffix=||
-(3, 0)       BinOp                	prefix=||	suffix=||
-(5, 0)       BinOp                	prefix=||	suffix=||
-(7, 0)       BinOp                	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(12, 4)      BinOp                	prefix=|(\n    |	suffix=|\n)|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(-1, -1)     Sub                  	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(-1, -1)     Div                  	prefix=||	suffix=| |
-(5, 4)       Name f               	prefix=||	suffix=||
-(7, 0)       Name g               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(7, 5)       BinOp                	prefix=|(|	suffix=|)|
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     BitOr                	prefix=||	suffix=||
-(9, 25)      BinOp                	prefix=||	suffix=||
-(12, 4)      Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(12, 8)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 5)       Name h               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(7, 9)       Name i               	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     BitAnd               	prefix=||	suffix=||
-(9, 22)      Name o               	prefix=||	suffix=| |
-(9, 25)      Name p               	prefix=||	suffix=| |
-(-1, -1)     RShift               	prefix=||	suffix=|  |
-(9, 31)      Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=| |
-(-1, -1)     LShift               	prefix=||	suffix=|  |
-(9, 19)      Name n               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     Add                  	prefix=||	suffix=||
-(9, 8)       BinOp                	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name j               	prefix=||	suffix=||
-(-1, -1)     FloorDiv             	prefix=||	suffix=||
-(9, 3)       Name k               	prefix=||	suffix=|  |
-(9, 8)       Name l               	prefix=||	suffix=| |
-(-1, -1)     BitXor               	prefix=||	suffix=||
-(9, 11)      Name m               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(3, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(5, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(7, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(12, 4)      BinOp                	prefix=|(\n    |	suffix=|\n)|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Sub                  	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Div                  	prefix=||	suffix=| |	indent=||
+(5, 4)       Name f               	prefix=||	suffix=||	indent=||
+(7, 0)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(7, 5)       BinOp                	prefix=|(|	suffix=|)|	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     BitOr                	prefix=||	suffix=||	indent=||
+(9, 25)      BinOp                	prefix=||	suffix=||	indent=||
+(12, 4)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(12, 8)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 5)       Name h               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(7, 9)       Name i               	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     BitAnd               	prefix=||	suffix=||	indent=||
+(9, 22)      Name o               	prefix=||	suffix=| |	indent=||
+(9, 25)      Name p               	prefix=||	suffix=| |	indent=||
+(-1, -1)     RShift               	prefix=||	suffix=|  |	indent=||
+(9, 31)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=| |	indent=||
+(-1, -1)     LShift               	prefix=||	suffix=|  |	indent=||
+(9, 19)      Name n               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=||	indent=||
+(9, 8)       BinOp                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     FloorDiv             	prefix=||	suffix=||	indent=||
+(9, 3)       Name k               	prefix=||	suffix=|  |	indent=||
+(9, 8)       Name l               	prefix=||	suffix=| |	indent=||
+(-1, -1)     BitXor               	prefix=||	suffix=||	indent=||
+(9, 11)      Name m               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/boolop.out
+++ b/testdata/ast/golden/2.7/boolop.out
@@ -1,54 +1,54 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       BoolOp               	prefix=||	suffix=||
-(3, 0)       BoolOp               	prefix=||	suffix=||
-(5, 0)       BoolOp               	prefix=||	suffix=||
-(7, 0)       BoolOp               	prefix=||	suffix=||
-(9, 0)       BoolOp               	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 6)       Name b               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(3, 5)       Name d               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(5, 1)       BoolOp               	prefix=|(|	suffix=|)|
-(5, 20)      Name h               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(7, 0)       BoolOp               	prefix=||	suffix=||
-(7, 20)      Name k               	prefix=|(|	suffix=|)|
-(-1, -1)     Or                   	prefix=||	suffix=||
-(9, 0)       BoolOp               	prefix=||	suffix=||
-(9, 29)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(5, 1)       Name e               	prefix=||	suffix=| |
-(5, 8)       BoolOp               	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(7, 1)       Name i               	prefix=|(|	suffix=|)|
-(7, 11)      Name j               	prefix=||	suffix=|   |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(9, 0)       Name l               	prefix=||	suffix=| |
-(9, 8)       Name m               	prefix=||	suffix=|        |
-(9, 22)      Name n               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(5, 8)       Name f               	prefix=||	suffix=| |
-(5, 13)      Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(3, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(5, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(7, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(9, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 6)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(3, 5)       Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(5, 1)       BoolOp               	prefix=|(|	suffix=|)|	indent=||
+(5, 20)      Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(7, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(7, 20)      Name k               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(9, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(9, 29)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(5, 1)       Name e               	prefix=||	suffix=| |	indent=||
+(5, 8)       BoolOp               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(7, 1)       Name i               	prefix=|(|	suffix=|)|	indent=||
+(7, 11)      Name j               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(9, 0)       Name l               	prefix=||	suffix=| |	indent=||
+(9, 8)       Name m               	prefix=||	suffix=|        |	indent=||
+(9, 22)      Name n               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(5, 8)       Name f               	prefix=||	suffix=| |	indent=||
+(5, 13)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/call.out
+++ b/testdata/ast/golden/2.7/call.out
@@ -1,60 +1,60 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Call                 	prefix=||	suffix=||
-(3, 0)       Call                 	prefix=||	suffix=||
-(5, 0)       Call                 	prefix=||	suffix=||
-(7, 0)       Call                 	prefix=||	suffix=||
-(9, 1)       Call                 	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(3, 2)       Name d               	prefix=||	suffix=||
-(3, 5)       Name e               	prefix=||	suffix=||
-(-1, -1)     keyword f            	prefix=||	suffix=||
-(3, 14)      Name args            	prefix=||	suffix=||
-(3, 22)      Name kwargs          	prefix=||	suffix=||
-(5, 0)       Name h               	prefix=||	suffix=|  |
-(5, 6)       Name i               	prefix=||	suffix=| |
-(-1, -1)     keyword k            	prefix=||	suffix=||
-(-1, -1)     keyword m            	prefix=||	suffix=||
-(5, 13)      Name j               	prefix=|  |	suffix=|   |
-(5, 33)      Name o               	prefix=||	suffix=||
-(7, 0)       Name p               	prefix=||	suffix=||
-(7, 2)       Name q               	prefix=||	suffix=||
-(7, 5)       Name r               	prefix=||	suffix=||
-(-1, -1)     keyword s            	prefix=||	suffix=||
-(-1, -1)     keyword u            	prefix=||	suffix=||
-(9, 1)       Name q               	prefix=|(|	suffix=|)|
-(9, 4)       Name r               	prefix=||	suffix=||
-(9, 7)       Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 10)      Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 22)      Name l               	prefix=| |	suffix=||
-(5, 27)      Name n               	prefix=| |	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 10)      Name t               	prefix=||	suffix=||
-(7, 16)      Name v               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Call                 	prefix=||	suffix=||	indent=||
+(3, 0)       Call                 	prefix=||	suffix=||	indent=||
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(7, 0)       Call                 	prefix=||	suffix=||	indent=||
+(9, 1)       Call                 	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(3, 2)       Name d               	prefix=||	suffix=||	indent=||
+(3, 5)       Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword f            	prefix=||	suffix=||	indent=||
+(3, 14)      Name args            	prefix=||	suffix=||	indent=||
+(3, 22)      Name kwargs          	prefix=||	suffix=||	indent=||
+(5, 0)       Name h               	prefix=||	suffix=|  |	indent=||
+(5, 6)       Name i               	prefix=||	suffix=| |	indent=||
+(-1, -1)     keyword k            	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword m            	prefix=||	suffix=||	indent=||
+(5, 13)      Name j               	prefix=|  |	suffix=|   |	indent=||
+(5, 33)      Name o               	prefix=||	suffix=||	indent=||
+(7, 0)       Name p               	prefix=||	suffix=||	indent=||
+(7, 2)       Name q               	prefix=||	suffix=||	indent=||
+(7, 5)       Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword s            	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword u            	prefix=||	suffix=||	indent=||
+(9, 1)       Name q               	prefix=|(|	suffix=|)|	indent=||
+(9, 4)       Name r               	prefix=||	suffix=||	indent=||
+(9, 7)       Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 10)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 22)      Name l               	prefix=| |	suffix=||	indent=||
+(5, 27)      Name n               	prefix=| |	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 10)      Name t               	prefix=||	suffix=||	indent=||
+(7, 16)      Name v               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/classdef.out
+++ b/testdata/ast/golden/2.7/classdef.out
@@ -1,26 +1,26 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       ClassDef a           	prefix=||	suffix=||
-(4, 0)       ClassDef d           	prefix=|\n|	suffix=||
-(9, 0)       ClassDef g           	prefix=|\n|	suffix=||
-(12, 0)      ClassDef h           	prefix=|\n|	suffix=||
-(15, 0)      ClassDef i           	prefix=|\n|	suffix=||
-(1, 8)       Name object          	prefix=||	suffix=||
-(2, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(6, 15)      Name e               	prefix=||	suffix=| |
-(6, 20)      Name f               	prefix=|  |	suffix=||
-(7, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(4, 1)       Name b               	prefix=||	suffix=||
-(5, 0)       Call                 	prefix=||	suffix=||
-(10, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(13, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(15, 8)      Name j               	prefix=||	suffix=||
-(15, 11)     Name k               	prefix=| |	suffix=||
-(16, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 1)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       ClassDef a           	prefix=||	suffix=||	indent=||
+(4, 0)       ClassDef d           	prefix=|\n|	suffix=||	indent=||
+(9, 0)       ClassDef g           	prefix=|\n|	suffix=||	indent=||
+(12, 0)      ClassDef h           	prefix=|\n|	suffix=||	indent=||
+(15, 0)      ClassDef i           	prefix=|\n|	suffix=||	indent=||
+(1, 8)       Name object          	prefix=||	suffix=||	indent=||
+(2, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(6, 15)      Name e               	prefix=||	suffix=| |	indent=||
+(6, 20)      Name f               	prefix=|  |	suffix=||	indent=||
+(7, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 1)       Name b               	prefix=||	suffix=||	indent=||
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(10, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(13, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(15, 8)      Name j               	prefix=||	suffix=||	indent=||
+(15, 11)     Name k               	prefix=| |	suffix=||	indent=||
+(16, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 1)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/compare.out
+++ b/testdata/ast/golden/2.7/compare.out
@@ -1,53 +1,53 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Compare              	prefix=||	suffix=||
-(3, 0)       Compare              	prefix=||	suffix=||
-(5, 0)       Compare              	prefix=||	suffix=||
-(7, 0)       Compare              	prefix=||	suffix=||
-(9, 1)       Compare              	prefix=|(|	suffix=|)|
-(11, 0)      Compare              	prefix=||	suffix=||
-(13, 0)      Compare              	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Lt                   	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(-1, -1)     Gt                   	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(-1, -1)     GtE                  	prefix=||	suffix=|  |
-(-1, -1)     Lt                   	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=||
-(5, 8)       Name g               	prefix=||	suffix=||
-(7, 0)       Name h               	prefix=||	suffix=|  |
-(-1, -1)     NotIn                	prefix=||	suffix=|  |
-(7, 11)      Name j               	prefix=||	suffix=||
-(9, 1)       Name i               	prefix=||	suffix=|  |
-(-1, -1)     IsNot                	prefix=||	suffix=| |
-(9, 13)      Name k               	prefix=||	suffix=||
-(11, 0)      Name l               	prefix=||	suffix=|   |
-(-1, -1)     Is                   	prefix=||	suffix=| |
-(11, 7)      Name m               	prefix=||	suffix=||
-(13, 0)      Name n               	prefix=||	suffix=|  |
-(-1, -1)     In                   	prefix=||	suffix=| |
-(13, 6)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Compare              	prefix=||	suffix=||	indent=||
+(3, 0)       Compare              	prefix=||	suffix=||	indent=||
+(5, 0)       Compare              	prefix=||	suffix=||	indent=||
+(7, 0)       Compare              	prefix=||	suffix=||	indent=||
+(9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
+(11, 0)      Compare              	prefix=||	suffix=||	indent=||
+(13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Lt                   	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Gt                   	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     GtE                  	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=||	indent=||
+(5, 8)       Name g               	prefix=||	suffix=||	indent=||
+(7, 0)       Name h               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     NotIn                	prefix=||	suffix=|  |	indent=||
+(7, 11)      Name j               	prefix=||	suffix=||	indent=||
+(9, 1)       Name i               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     IsNot                	prefix=||	suffix=| |	indent=||
+(9, 13)      Name k               	prefix=||	suffix=||	indent=||
+(11, 0)      Name l               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Is                   	prefix=||	suffix=| |	indent=||
+(11, 7)      Name m               	prefix=||	suffix=||	indent=||
+(13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     In                   	prefix=||	suffix=| |	indent=||
+(13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/compare2.out
+++ b/testdata/ast/golden/2.7/compare2.out
@@ -1,8 +1,8 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(1, 0)       Compare              	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     NotEq                	prefix=||	suffix=| |
-(1, 5)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(1, 0)       Compare              	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     NotEq                	prefix=||	suffix=| |	indent=||
+(1, 5)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/compexps.out
+++ b/testdata/ast/golden/2.7/compexps.out
@@ -1,108 +1,108 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       SetComp              	prefix=||	suffix=||
-(3, 3)       SetComp              	prefix=||	suffix=||
-(5, 1)       SetComp              	prefix=||	suffix=||
-(7, 1)       ListComp             	prefix=||	suffix=||
-(9, 3)       ListComp             	prefix=||	suffix=||
-(11, 1)      ListComp             	prefix=||	suffix=||
-(13, 1)      GeneratorExp         	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(5, 1)       Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(7, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(9, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(11, 1)      Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 7)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 17)      Name c               	prefix=||	suffix=|    |
-(3, 26)      Name d               	prefix=||	suffix=|    |
-(3, 40)      Name e               	prefix=||	suffix=|  |
-(3, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 7)       Name g               	prefix=||	suffix=| |
-(5, 12)      Name h               	prefix=||	suffix=| |
-(5, 17)      Name i               	prefix=||	suffix=| |
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 28)      Name k               	prefix=||	suffix=| |
-(5, 33)      Name l               	prefix=||	suffix=| |
-(5, 39)      Name m               	prefix=||	suffix=| |
-(5, 44)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 7)       Name a               	prefix=||	suffix=| |
-(7, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 17)      Name c               	prefix=||	suffix=|    |
-(9, 26)      Name d               	prefix=||	suffix=|    |
-(9, 40)      Name e               	prefix=||	suffix=|  |
-(9, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 7)      Name g               	prefix=||	suffix=| |
-(11, 12)     Name h               	prefix=||	suffix=| |
-(11, 17)     Name i               	prefix=||	suffix=| |
-(11, 22)     Name j               	prefix=||	suffix=| |
-(11, 28)     Name k               	prefix=||	suffix=| |
-(11, 33)     Name l               	prefix=||	suffix=| |
-(11, 39)     Name m               	prefix=||	suffix=| |
-(11, 44)     Name o               	prefix=||	suffix=||
-(13, 2)      Name p               	prefix=||	suffix=||
-(13, 5)      Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 12)     Tuple                	prefix=||	suffix=||
-(13, 20)     Name r               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 12)     Name p               	prefix=||	suffix=||
-(13, 15)     Name q               	prefix=||	suffix=| |
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       SetComp              	prefix=||	suffix=||	indent=||
+(3, 3)       SetComp              	prefix=||	suffix=||	indent=||
+(5, 1)       SetComp              	prefix=||	suffix=||	indent=||
+(7, 1)       ListComp             	prefix=||	suffix=||	indent=||
+(9, 3)       ListComp             	prefix=||	suffix=||	indent=||
+(11, 1)      ListComp             	prefix=||	suffix=||	indent=||
+(13, 1)      GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(5, 1)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(7, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(9, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(11, 1)      Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(3, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(3, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(3, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 7)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name h               	prefix=||	suffix=| |	indent=||
+(5, 17)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 28)      Name k               	prefix=||	suffix=| |	indent=||
+(5, 33)      Name l               	prefix=||	suffix=| |	indent=||
+(5, 39)      Name m               	prefix=||	suffix=| |	indent=||
+(5, 44)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(7, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(9, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(9, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(9, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 7)      Name g               	prefix=||	suffix=| |	indent=||
+(11, 12)     Name h               	prefix=||	suffix=| |	indent=||
+(11, 17)     Name i               	prefix=||	suffix=| |	indent=||
+(11, 22)     Name j               	prefix=||	suffix=| |	indent=||
+(11, 28)     Name k               	prefix=||	suffix=| |	indent=||
+(11, 33)     Name l               	prefix=||	suffix=| |	indent=||
+(11, 39)     Name m               	prefix=||	suffix=| |	indent=||
+(11, 44)     Name o               	prefix=||	suffix=||	indent=||
+(13, 2)      Name p               	prefix=||	suffix=||	indent=||
+(13, 5)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 12)     Tuple                	prefix=||	suffix=||	indent=||
+(13, 20)     Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 12)     Name p               	prefix=||	suffix=||	indent=||
+(13, 15)     Name q               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/del.out
+++ b/testdata/ast/golden/2.7/del.out
@@ -1,16 +1,16 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Delete               	prefix=||	suffix=|\n|
-(3, 0)       Delete               	prefix=|\n|	suffix=|\n|
-(5, 0)       Delete               	prefix=|\n|	suffix=|\n|
-(1, 4)       Name a               	prefix=||	suffix=||
-(3, 4)       Name b               	prefix=||	suffix=||
-(3, 7)       Name c               	prefix=||	suffix=||
-(5, 7)       Name d               	prefix=||	suffix=|  |
-(5, 11)      Name e               	prefix=||	suffix=|   |
-(5, 22)      Name f               	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Delete               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Delete               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Delete               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 4)       Name a               	prefix=||	suffix=||	indent=||
+(3, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 7)       Name c               	prefix=||	suffix=||	indent=||
+(5, 7)       Name d               	prefix=||	suffix=|  |	indent=||
+(5, 11)      Name e               	prefix=||	suffix=|   |	indent=||
+(5, 22)      Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/dict.out
+++ b/testdata/ast/golden/2.7/dict.out
@@ -1,57 +1,57 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(10, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Dict                 	prefix=||	suffix=||
-(3, 0)       Dict                 	prefix=||	suffix=||
-(5, 0)       Dict                 	prefix=||	suffix=||
-(10, 0)      Dict                 	prefix=||	suffix=||
-(15, 0)      Dict                 	prefix=||	suffix=||
-(19, 0)      Dict                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=|  |	suffix=||
-(3, 9)       Name e               	prefix=||	suffix=||
-(3, 15)      Name g               	prefix=||	suffix=|   |
-(3, 6)       Name d               	prefix=||	suffix=||
-(3, 11)      Name f               	prefix=||	suffix=||
-(3, 22)      Name h               	prefix=||	suffix=|   |
-(6, 3)       Name i               	prefix=|\n   |	suffix=||
-(7, 1)       Name k               	prefix=||	suffix=|    |
-(8, 1)       Name n               	prefix=||	suffix=||
-(8, 6)       Name p               	prefix=||	suffix=||
-(6, 7)       Name j               	prefix=||	suffix=||
-(7, 11)      Name l               	prefix=||	suffix=|   |
-(8, 3)       Name o               	prefix=||	suffix=||
-(8, 8)       Name q               	prefix=||	suffix=|   |
-(11, 3)      Name r               	prefix=|\n   |	suffix=||
-(12, 3)      Name t               	prefix=||	suffix=||
-(11, 6)      Name s               	prefix=||	suffix=||
-(12, 6)      Name u               	prefix=||	suffix=||
-(19, 1)      Name w               	prefix=||	suffix=||
-(19, 4)      Name x               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(10, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(3, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(5, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(10, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(15, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(19, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=|  |	suffix=||	indent=||
+(3, 9)       Name e               	prefix=||	suffix=||	indent=||
+(3, 15)      Name g               	prefix=||	suffix=|   |	indent=||
+(3, 6)       Name d               	prefix=||	suffix=||	indent=||
+(3, 11)      Name f               	prefix=||	suffix=||	indent=||
+(3, 22)      Name h               	prefix=||	suffix=|   |	indent=||
+(6, 3)       Name i               	prefix=|\n   |	suffix=||	indent=||
+(7, 1)       Name k               	prefix=||	suffix=|    |	indent=||
+(8, 1)       Name n               	prefix=||	suffix=||	indent=||
+(8, 6)       Name p               	prefix=||	suffix=||	indent=||
+(6, 7)       Name j               	prefix=||	suffix=||	indent=||
+(7, 11)      Name l               	prefix=||	suffix=|   |	indent=||
+(8, 3)       Name o               	prefix=||	suffix=||	indent=||
+(8, 8)       Name q               	prefix=||	suffix=|   |	indent=||
+(11, 3)      Name r               	prefix=|\n   |	suffix=||	indent=||
+(12, 3)      Name t               	prefix=||	suffix=||	indent=||
+(11, 6)      Name s               	prefix=||	suffix=||	indent=||
+(12, 6)      Name u               	prefix=||	suffix=||	indent=||
+(19, 1)      Name w               	prefix=||	suffix=||	indent=||
+(19, 4)      Name x               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/dictcomp.out
+++ b/testdata/ast/golden/2.7/dictcomp.out
@@ -1,28 +1,28 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       DictComp             	prefix=||	suffix=||
-(3, 3)       DictComp             	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name e               	prefix=||	suffix=||
-(3, 5)       Name f               	prefix=||	suffix=|   |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 10)      Name c               	prefix=||	suffix=| |
-(1, 15)      Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(4, 2)       Name h               	prefix=||	suffix=| |
-(4, 9)       Name i               	prefix=||	suffix=|   |
-(4, 19)      Name j               	prefix=||	suffix=| |
-(4, 26)      Name k               	prefix=||	suffix=| |
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       DictComp             	prefix=||	suffix=||	indent=||
+(3, 3)       DictComp             	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name e               	prefix=||	suffix=||	indent=||
+(3, 5)       Name f               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 10)      Name c               	prefix=||	suffix=| |	indent=||
+(1, 15)      Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(4, 2)       Name h               	prefix=||	suffix=| |	indent=||
+(4, 9)       Name i               	prefix=||	suffix=|   |	indent=||
+(4, 19)      Name j               	prefix=||	suffix=| |	indent=||
+(4, 26)      Name k               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/empty.out
+++ b/testdata/ast/golden/2.7/empty.out
@@ -1,1 +1,1 @@
-(-1, -1)     Module               	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/exec.out
+++ b/testdata/ast/golden/2.7/exec.out
@@ -1,23 +1,23 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Exec                 	prefix=||	suffix=|\n|
-(3, 0)       Exec                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Exec                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Exec                 	prefix=|\n|	suffix=|\n|
-(1, 5)       Name a               	prefix=||	suffix=||
-(3, 5)       Name b               	prefix=||	suffix=| |
-(3, 10)      Name c               	prefix=||	suffix=||
-(5, 9)       Name d               	prefix=||	suffix=|     |
-(5, 20)      Name e               	prefix=||	suffix=||
-(5, 22)      Name f               	prefix=||	suffix=||
-(7, 5)       Name g               	prefix=||	suffix=| |
-(7, 10)      Name h               	prefix=||	suffix=|   |
-(7, 17)      Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Exec                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Exec                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Exec                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Exec                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 5)       Name a               	prefix=||	suffix=||	indent=||
+(3, 5)       Name b               	prefix=||	suffix=| |	indent=||
+(3, 10)      Name c               	prefix=||	suffix=||	indent=||
+(5, 9)       Name d               	prefix=||	suffix=|     |	indent=||
+(5, 20)      Name e               	prefix=||	suffix=||	indent=||
+(5, 22)      Name f               	prefix=||	suffix=||	indent=||
+(7, 5)       Name g               	prefix=||	suffix=| |	indent=||
+(7, 10)      Name h               	prefix=||	suffix=|   |	indent=||
+(7, 17)      Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/for.out
+++ b/testdata/ast/golden/2.7/for.out
@@ -1,26 +1,26 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       For                  	prefix=||	suffix=||
-(4, 0)       For                  	prefix=|\n|	suffix=||
-(1, 4)       Name a               	prefix=||	suffix=| |
-(1, 9)       Name b               	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(4, 6)       Name d               	prefix=||	suffix=|    |
-(4, 21)      Name e               	prefix=||	suffix=|   |
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(6, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name c               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name f               	prefix=||	suffix=||
-(6, 2)       Name g               	prefix=||	suffix=||
-(8, 2)       Name h               	prefix=||	suffix=||
-(9, 2)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       For                  	prefix=||	suffix=||	indent=||
+(4, 0)       For                  	prefix=|\n|	suffix=||	indent=||
+(1, 4)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 9)       Name b               	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 6)       Name d               	prefix=||	suffix=|    |	indent=||
+(4, 21)      Name e               	prefix=||	suffix=|   |	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(6, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(6, 2)       Name g               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name h               	prefix=||	suffix=||	indent=|  |
+(9, 2)       Name i               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/fromimport.out
+++ b/testdata/ast/golden/2.7/fromimport.out
@@ -1,15 +1,15 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       ImportFrom a         	prefix=||	suffix=|\n|
-(3, 0)       ImportFrom c         	prefix=|\n|	suffix=|\n|
-(5, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|
-(7, 0)       ImportFrom g.h.i     	prefix=|\n|	suffix=|\n|
-(9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|
-(11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|
-(13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|
-(-1, -1)     alias b              	prefix=| |	suffix=||
-(-1, -1)     alias d              	prefix=| |	suffix=||
-(-1, -1)     alias f              	prefix=| |	suffix=||
-(-1, -1)     alias j              	prefix=| |	suffix=||
-(-1, -1)     alias l              	prefix=| |	suffix=||
-(-1, -1)     alias n              	prefix=||	suffix=||
-(-1, -1)     alias p              	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       ImportFrom a         	prefix=||	suffix=|\n|	indent=||
+(3, 0)       ImportFrom c         	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       ImportFrom g.h.i     	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(-1, -1)     alias b              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias d              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias f              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias j              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias l              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias n              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias p              	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/functiondef.out
+++ b/testdata/ast/golden/2.7/functiondef.out
@@ -1,82 +1,82 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(4, 0)       FunctionDef d        	prefix=|\n|	suffix=||
-(7, 0)       FunctionDef k        	prefix=|\n|	suffix=||
-(12, 0)      FunctionDef v        	prefix=|\n|	suffix=||
-(18, 0)      FunctionDef x        	prefix=|\n|	suffix=||
-(21, 0)      ClassDef A           	prefix=|\n|	suffix=||
-(27, 0)      FunctionDef f        	prefix=|\n|	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(10, 2)      Return               	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(16, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(12, 0)      Call                 	prefix=||	suffix=||
-(13, 1)      Name p               	prefix=||	suffix=||
-(14, 1)      Call                 	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(19, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(22, 2)      FunctionDef d        	prefix=|  |	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=|\n    |
-(30, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(1, 6)       Name b               	prefix=||	suffix=||
-(2, 2)       Name c               	prefix=||	suffix=||
-(4, 13)      Name e               	prefix=||	suffix=|  |
-(4, 17)      Name f               	prefix=||	suffix=||
-(4, 20)      Name g               	prefix=||	suffix=||
-(5, 2)       Name j               	prefix=||	suffix=||
-(8, 2)       Name l               	prefix=||	suffix=||
-(9, 2)       Name m               	prefix=||	suffix=||
-(10, 9)      Name n               	prefix=| |	suffix=||
-(16, 2)      Name w               	prefix=||	suffix=||
-(12, 1)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 1)      Name q               	prefix=||	suffix=||
-(14, 3)      Name r               	prefix=||	suffix=||
-(14, 6)      Name s               	prefix=||	suffix=||
-(-1, -1)     keyword t            	prefix=||	suffix=||
-(18, 6)      Name y               	prefix=||	suffix=||
-(18, 9)      Name z               	prefix=||	suffix=||
-(18, 11)     Name a               	prefix=||	suffix=||
-(19, 2)      Name b               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(25, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(22, 3)      Name b               	prefix=||	suffix=||
-(23, 3)      Name c               	prefix=||	suffix=||
-(28, 4)      Name g               	prefix=||	suffix=||
-(28, 7)      Name h               	prefix=||	suffix=||
-(28, 9)      Name i               	prefix=||	suffix=||
-(30, 2)      Name j               	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 11)     Name u               	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(25, 4)      Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(4, 0)       FunctionDef d        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef k        	prefix=|\n|	suffix=||	indent=||
+(12, 0)      FunctionDef v        	prefix=|\n|	suffix=||	indent=||
+(18, 0)      FunctionDef x        	prefix=|\n|	suffix=||	indent=||
+(21, 0)      ClassDef A           	prefix=|\n|	suffix=||	indent=||
+(27, 0)      FunctionDef f        	prefix=|\n|	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(10, 2)      Return               	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(16, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(12, 0)      Call                 	prefix=||	suffix=||	indent=||
+(13, 1)      Name p               	prefix=||	suffix=||	indent=||
+(14, 1)      Call                 	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(19, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(22, 2)      FunctionDef d        	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=|\n    |	indent=||
+(30, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(1, 6)       Name b               	prefix=||	suffix=||	indent=||
+(2, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(4, 13)      Name e               	prefix=||	suffix=|  |	indent=||
+(4, 17)      Name f               	prefix=||	suffix=||	indent=||
+(4, 20)      Name g               	prefix=||	suffix=||	indent=||
+(5, 2)       Name j               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name l               	prefix=||	suffix=||	indent=|  |
+(9, 2)       Name m               	prefix=||	suffix=||	indent=|  |
+(10, 9)      Name n               	prefix=| |	suffix=||	indent=|  |
+(16, 2)      Name w               	prefix=||	suffix=||	indent=|  |
+(12, 1)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 1)      Name q               	prefix=||	suffix=||	indent=||
+(14, 3)      Name r               	prefix=||	suffix=||	indent=||
+(14, 6)      Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword t            	prefix=||	suffix=||	indent=||
+(18, 6)      Name y               	prefix=||	suffix=||	indent=||
+(18, 9)      Name z               	prefix=||	suffix=||	indent=||
+(18, 11)     Name a               	prefix=||	suffix=||	indent=||
+(19, 2)      Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=|  |
+(25, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(22, 3)      Name b               	prefix=||	suffix=||	indent=|  |
+(23, 3)      Name c               	prefix=||	suffix=||	indent=|  |
+(28, 4)      Name g               	prefix=||	suffix=||	indent=||
+(28, 7)      Name h               	prefix=||	suffix=||	indent=||
+(28, 9)      Name i               	prefix=||	suffix=||	indent=||
+(30, 2)      Name j               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 11)     Name u               	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(25, 4)      Name e               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/functiondef2.out
+++ b/testdata/ast/golden/2.7/functiondef2.out
@@ -1,14 +1,14 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(1, 7)       Tuple                	prefix=|(|	suffix=|)|
-(1, 14)      Name d               	prefix=||	suffix=||
-(2, 2)       Name e               	prefix=||	suffix=||
-(1, 7)       Name b               	prefix=||	suffix=||
-(1, 10)      Name c               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(1, 7)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(1, 14)      Name d               	prefix=||	suffix=||	indent=||
+(2, 2)       Name e               	prefix=||	suffix=||	indent=|  |
+(1, 7)       Name b               	prefix=||	suffix=||	indent=||
+(1, 10)      Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/generators.out
+++ b/testdata/ast/golden/2.7/generators.out
@@ -1,46 +1,46 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       GeneratorExp         	prefix=|(|	suffix=|)|
-(3, 3)       GeneratorExp         	prefix=|(  |	suffix=|)|
-(5, 1)       GeneratorExp         	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(5, 1)       Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 7)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 17)      Name c               	prefix=||	suffix=|    |
-(3, 26)      Name d               	prefix=||	suffix=|    |
-(3, 40)      Name e               	prefix=||	suffix=|  |
-(3, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 7)       Name g               	prefix=||	suffix=| |
-(5, 12)      Name h               	prefix=||	suffix=| |
-(5, 17)      Name i               	prefix=||	suffix=| |
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 28)      Name k               	prefix=||	suffix=| |
-(5, 33)      Name l               	prefix=||	suffix=| |
-(5, 39)      Name m               	prefix=||	suffix=| |
-(5, 44)      Name o               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(3, 3)       GeneratorExp         	prefix=|(  |	suffix=|)|	indent=||
+(5, 1)       GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(5, 1)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(3, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(3, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(3, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 7)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name h               	prefix=||	suffix=| |	indent=||
+(5, 17)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 28)      Name k               	prefix=||	suffix=| |	indent=||
+(5, 33)      Name l               	prefix=||	suffix=| |	indent=||
+(5, 39)      Name m               	prefix=||	suffix=| |	indent=||
+(5, 44)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/global.out
+++ b/testdata/ast/golden/2.7/global.out
@@ -1,4 +1,4 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Global               	prefix=||	suffix=|\n|
-(3, 0)       Global               	prefix=|\n|	suffix=|\n|
-(5, 0)       Global               	prefix=|\n|	suffix=|\n|
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Global               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Global               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Global               	prefix=|\n|	suffix=|\n|	indent=||

--- a/testdata/ast/golden/2.7/if.out
+++ b/testdata/ast/golden/2.7/if.out
@@ -1,55 +1,55 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       If                   	prefix=||	suffix=||
-(4, 0)       If                   	prefix=|\n|	suffix=||
-(9, 0)       If                   	prefix=|\n|	suffix=||
-(18, 0)      If                   	prefix=|\n|	suffix=||
-(1, 3)       Name a               	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(4, 3)       Name c               	prefix=||	suffix=||
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 3)       Name e               	prefix=||	suffix=||
-(10, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(11, 5)      If                   	prefix=||	suffix=||
-(18, 3)      Name m               	prefix=||	suffix=||
-(19, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(20, 5)      If                   	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name e               	prefix=||	suffix=||
-(7, 2)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(10, 2)      Name g               	prefix=||	suffix=||
-(11, 5)      Name h               	prefix=||	suffix=||
-(12, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(13, 5)      If                   	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(19, 2)      Name n               	prefix=||	suffix=||
-(20, 5)      Name o               	prefix=||	suffix=||
-(21, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(23, 2)      If                   	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(12, 2)      Name i               	prefix=||	suffix=||
-(13, 5)      Name j               	prefix=||	suffix=||
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(21, 2)      Name p               	prefix=||	suffix=||
-(23, 5)      Name q               	prefix=||	suffix=||
-(24, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 2)      Name k               	prefix=||	suffix=||
-(16, 2)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(24, 4)      Name r               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       If                   	prefix=||	suffix=||	indent=||
+(4, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(9, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(18, 0)      If                   	prefix=|\n|	suffix=||	indent=||
+(1, 3)       Name a               	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 3)       Name c               	prefix=||	suffix=||	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 3)       Name e               	prefix=||	suffix=||	indent=||
+(10, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(11, 5)      If                   	prefix=||	suffix=||	indent=||
+(18, 3)      Name m               	prefix=||	suffix=||	indent=||
+(19, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(20, 5)      If                   	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name e               	prefix=||	suffix=||	indent=|  |
+(7, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(10, 2)      Name g               	prefix=||	suffix=||	indent=|  |
+(11, 5)      Name h               	prefix=||	suffix=||	indent=||
+(12, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(13, 5)      If                   	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(19, 2)      Name n               	prefix=||	suffix=||	indent=|  |
+(20, 5)      Name o               	prefix=||	suffix=||	indent=||
+(21, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(23, 2)      If                   	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(12, 2)      Name i               	prefix=||	suffix=||	indent=|  |
+(13, 5)      Name j               	prefix=||	suffix=||	indent=||
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(16, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(21, 2)      Name p               	prefix=||	suffix=||	indent=|  |
+(23, 5)      Name q               	prefix=||	suffix=||	indent=|  |
+(24, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 2)      Name k               	prefix=||	suffix=||	indent=|  |
+(16, 2)      Name l               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(24, 4)      Name r               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/ifexp.out
+++ b/testdata/ast/golden/2.7/ifexp.out
@@ -1,40 +1,40 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       IfExp                	prefix=||	suffix=||
-(3, 1)       IfExp                	prefix=|(|	suffix=|)|
-(5, 0)       IfExp                	prefix=||	suffix=||
-(7, 1)       IfExp                	prefix=|(|	suffix=|)|
-(1, 5)       Name b               	prefix=||	suffix=| |
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name c               	prefix=||	suffix=||
-(3, 11)      Name e               	prefix=|(|	suffix=|)|
-(3, 1)       Name d               	prefix=||	suffix=|   |
-(3, 22)      Name f               	prefix=||	suffix=| |
-(5, 5)       Name h               	prefix=||	suffix=| |
-(5, 0)       Name g               	prefix=||	suffix=| |
-(5, 12)      IfExp                	prefix=||	suffix=||
-(7, 9)       Name m               	prefix=||	suffix=| |
-(7, 2)       Tuple                	prefix=|(|	suffix=|)|
-(7, 16)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 17)      Name j               	prefix=||	suffix=| |
-(5, 12)      Name i               	prefix=||	suffix=| |
-(5, 24)      Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 2)       Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       IfExp                	prefix=||	suffix=||	indent=||
+(3, 1)       IfExp                	prefix=|(|	suffix=|)|	indent=||
+(5, 0)       IfExp                	prefix=||	suffix=||	indent=||
+(7, 1)       IfExp                	prefix=|(|	suffix=|)|	indent=||
+(1, 5)       Name b               	prefix=||	suffix=| |	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name c               	prefix=||	suffix=||	indent=||
+(3, 11)      Name e               	prefix=|(|	suffix=|)|	indent=||
+(3, 1)       Name d               	prefix=||	suffix=|   |	indent=||
+(3, 22)      Name f               	prefix=||	suffix=| |	indent=||
+(5, 5)       Name h               	prefix=||	suffix=| |	indent=||
+(5, 0)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      IfExp                	prefix=||	suffix=||	indent=||
+(7, 9)       Name m               	prefix=||	suffix=| |	indent=||
+(7, 2)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(7, 16)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 17)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 24)      Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 2)       Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/import.out
+++ b/testdata/ast/golden/2.7/import.out
@@ -1,19 +1,19 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Import               	prefix=||	suffix=|\n|
-(3, 0)       Import               	prefix=|\n|	suffix=|\n|
-(5, 0)       Import               	prefix=|\n|	suffix=|\n|
-(7, 0)       Import               	prefix=|\n|	suffix=|\n|
-(9, 0)       Import               	prefix=|\n|	suffix=|\n|
-(11, 0)      Import               	prefix=|\n|	suffix=|\n|
-(-1, -1)     alias a              	prefix=||	suffix=||
-(-1, -1)     alias b              	prefix=||	suffix=||
-(-1, -1)     alias c              	prefix=||	suffix=||
-(-1, -1)     alias d              	prefix=||	suffix=||
-(-1, -1)     alias f              	prefix=||	suffix=||
-(-1, -1)     alias g              	prefix=||	suffix=||
-(-1, -1)     alias i              	prefix=||	suffix=||
-(-1, -1)     alias j              	prefix=||	suffix=||
-(-1, -1)     alias l              	prefix=||	suffix=||
-(-1, -1)     alias n              	prefix=||	suffix=||
-(-1, -1)     alias p.q.r          	prefix=||	suffix=||
-(-1, -1)     alias t.u.v          	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Import               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Import               	prefix=|\n|	suffix=|\n|	indent=||
+(-1, -1)     alias a              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias b              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias c              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias d              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias f              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias g              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias i              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias j              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias l              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias n              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias p.q.r          	prefix=||	suffix=||	indent=||
+(-1, -1)     alias t.u.v          	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/lambda.out
+++ b/testdata/ast/golden/2.7/lambda.out
@@ -1,36 +1,36 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Lambda               	prefix=||	suffix=||
-(3, 0)       Lambda               	prefix=||	suffix=||
-(5, 0)       Lambda               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(1, 10)      Name b               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(3, 15)      Name f               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 41)      Name o               	prefix=||	suffix=||
-(1, 7)       Name a               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 7)       Name c               	prefix=||	suffix=||
-(3, 10)      Name d               	prefix=||	suffix=||
-(3, 12)      Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 11)      Name g               	prefix=||	suffix=|  |
-(5, 15)      Name h               	prefix=||	suffix=||
-(5, 17)      Name i               	prefix=||	suffix=| |
-(5, 27)      Name k               	prefix=||	suffix=||
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 29)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Param                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(3, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(5, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(1, 10)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(3, 15)      Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 41)      Name o               	prefix=||	suffix=||	indent=||
+(1, 7)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 7)       Name c               	prefix=||	suffix=||	indent=||
+(3, 10)      Name d               	prefix=||	suffix=||	indent=||
+(3, 12)      Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 11)      Name g               	prefix=||	suffix=|  |	indent=||
+(5, 15)      Name h               	prefix=||	suffix=||	indent=||
+(5, 17)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 27)      Name k               	prefix=||	suffix=||	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 29)      Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Param                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/list.out
+++ b/testdata/ast/golden/2.7/list.out
@@ -1,62 +1,62 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       List                 	prefix=||	suffix=||
-(3, 0)       List                 	prefix=||	suffix=||
-(5, 0)       List                 	prefix=||	suffix=||
-(7, 0)       List                 	prefix=||	suffix=||
-(9, 0)       List                 	prefix=||	suffix=||
-(13, 0)      List                 	prefix=||	suffix=||
-(15, 0)      List                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 3)       Name b               	prefix=||	suffix=||
-(1, 5)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 1)       Name e               	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=|  |
-(5, 10)      Name g               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 1)       Name h               	prefix=||	suffix=||
-(7, 4)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(13, 9)      Name m               	prefix=||	suffix=||
-(13, 13)     Tuple                	prefix=|(|	suffix=|)|
-(13, 18)     Name o               	prefix=||	suffix=||
-(13, 22)     Tuple                	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name r               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Name k               	prefix=||	suffix=||
-(13, 5)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 13)     Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 22)     Name p               	prefix=||	suffix=||
-(13, 25)     Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       List                 	prefix=||	suffix=||	indent=||
+(3, 0)       List                 	prefix=||	suffix=||	indent=||
+(5, 0)       List                 	prefix=||	suffix=||	indent=||
+(7, 0)       List                 	prefix=||	suffix=||	indent=||
+(9, 0)       List                 	prefix=||	suffix=||	indent=||
+(13, 0)      List                 	prefix=||	suffix=||	indent=||
+(15, 0)      List                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 3)       Name b               	prefix=||	suffix=||	indent=||
+(1, 5)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 1)       Name e               	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=|  |	indent=||
+(5, 10)      Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 1)       Name h               	prefix=||	suffix=||	indent=||
+(7, 4)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 9)      Name m               	prefix=||	suffix=||	indent=||
+(13, 13)     Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 18)     Name o               	prefix=||	suffix=||	indent=||
+(13, 22)     Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Name k               	prefix=||	suffix=||	indent=||
+(13, 5)      Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 13)     Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 22)     Name p               	prefix=||	suffix=||	indent=||
+(13, 25)     Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/num.out
+++ b/testdata/ast/golden/2.7/num.out
@@ -1,25 +1,25 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(21, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(23, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Num                  	prefix=||	suffix=||
-(3, 0)       Num                  	prefix=||	suffix=||
-(5, 0)       Num                  	prefix=||	suffix=||
-(7, 0)       Num                  	prefix=||	suffix=||
-(9, 1)       Num                  	prefix=|(|	suffix=|)|
-(11, 0)      Num                  	prefix=||	suffix=||
-(13, 0)      Num                  	prefix=||	suffix=||
-(15, 0)      Num                  	prefix=||	suffix=||
-(17, 0)      Num                  	prefix=||	suffix=||
-(19, 0)      Num                  	prefix=||	suffix=||
-(21, 0)      Num                  	prefix=||	suffix=||
-(23, 0)      Num                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(21, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(23, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Num                  	prefix=||	suffix=||	indent=||
+(3, 0)       Num                  	prefix=||	suffix=||	indent=||
+(5, 0)       Num                  	prefix=||	suffix=||	indent=||
+(7, 0)       Num                  	prefix=||	suffix=||	indent=||
+(9, 1)       Num                  	prefix=|(|	suffix=|)|	indent=||
+(11, 0)      Num                  	prefix=||	suffix=||	indent=||
+(13, 0)      Num                  	prefix=||	suffix=||	indent=||
+(15, 0)      Num                  	prefix=||	suffix=||	indent=||
+(17, 0)      Num                  	prefix=||	suffix=||	indent=||
+(19, 0)      Num                  	prefix=||	suffix=||	indent=||
+(21, 0)      Num                  	prefix=||	suffix=||	indent=||
+(23, 0)      Num                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/print.out
+++ b/testdata/ast/golden/2.7/print.out
@@ -1,33 +1,33 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Print                	prefix=||	suffix=|\n|
-(3, 0)       Print                	prefix=|\n|	suffix=|\n|
-(5, 0)       Print                	prefix=|\n|	suffix=|\n|
-(7, 0)       Print                	prefix=|\n|	suffix=|\n|
-(9, 0)       Print                	prefix=|\n|	suffix=|\n|
-(11, 0)      Print                	prefix=|\n|	suffix=|\n|
-(1, 6)       Name a               	prefix=||	suffix=||
-(3, 6)       Name b               	prefix=||	suffix=||
-(3, 9)       Name c               	prefix=||	suffix=||
-(5, 8)       Name d               	prefix=||	suffix=|   |
-(5, 13)      Name e               	prefix=||	suffix=|   |
-(5, 20)      Name f               	prefix=||	suffix=||
-(7, 6)       Attribute h          	prefix=||	suffix=||
-(9, 11)      Name i               	prefix=||	suffix=|  |
-(9, 16)      Name j               	prefix=||	suffix=| |
-(9, 21)      Name k               	prefix=||	suffix=||
-(11, 8)      Name l               	prefix=||	suffix=||
-(11, 11)     Name m               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 6)       Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Print                	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Print                	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Print                	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Print                	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Print                	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Print                	prefix=|\n|	suffix=|\n|	indent=||
+(1, 6)       Name a               	prefix=||	suffix=||	indent=||
+(3, 6)       Name b               	prefix=||	suffix=||	indent=||
+(3, 9)       Name c               	prefix=||	suffix=||	indent=||
+(5, 8)       Name d               	prefix=||	suffix=|   |	indent=||
+(5, 13)      Name e               	prefix=||	suffix=|   |	indent=||
+(5, 20)      Name f               	prefix=||	suffix=||	indent=||
+(7, 6)       Attribute h          	prefix=||	suffix=||	indent=||
+(9, 11)      Name i               	prefix=||	suffix=|  |	indent=||
+(9, 16)      Name j               	prefix=||	suffix=| |	indent=||
+(9, 21)      Name k               	prefix=||	suffix=||	indent=||
+(11, 8)      Name l               	prefix=||	suffix=||	indent=||
+(11, 11)     Name m               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 6)       Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/raise.out
+++ b/testdata/ast/golden/2.7/raise.out
@@ -1,37 +1,37 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Raise                	prefix=||	suffix=|\n|
-(3, 0)       Raise                	prefix=|\n|	suffix=|\n|
-(5, 0)       TryFinally           	prefix=|\n|	suffix=||
-(16, 0)      Raise                	prefix=|\n|	suffix=|\n|
-(18, 0)      Raise                	prefix=|\n|	suffix=|\n|
-(1, 6)       Name a               	prefix=| |	suffix=||
-(3, 7)       Name b               	prefix=|  |	suffix=||
-(5, 0)       TryExcept            	prefix=|  |	suffix=||
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 6)      Name g               	prefix=| |	suffix=|  |
-(16, 12)     Name h               	prefix=||	suffix=||
-(18, 6)      Name i               	prefix=| |	suffix=||
-(18, 9)      Name j               	prefix=||	suffix=||
-(18, 12)     Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(6, 2)       Expr                 	prefix=||	suffix=|\n|
-(7, 0)       ExceptHandler        	prefix=||	suffix=||
-(14, 2)      Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(6, 2)       Name c               	prefix=||	suffix=||
-(8, 2)       TryExcept            	prefix=|  |	suffix=||
-(12, 2)      Raise                	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 4)       Expr                 	prefix=|    |	suffix=|\n|
-(10, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(9, 4)       Name d               	prefix=||	suffix=||
-(11, 4)      Raise                	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 10)     Name e               	prefix=| |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Raise                	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Raise                	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       TryFinally           	prefix=|\n|	suffix=||	indent=||
+(16, 0)      Raise                	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Raise                	prefix=|\n|	suffix=|\n|	indent=||
+(1, 6)       Name a               	prefix=| |	suffix=||	indent=||
+(3, 7)       Name b               	prefix=|  |	suffix=||	indent=||
+(5, 0)       TryExcept            	prefix=|  |	suffix=||	indent=||
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(16, 6)      Name g               	prefix=| |	suffix=|  |	indent=||
+(16, 12)     Name h               	prefix=||	suffix=||	indent=||
+(18, 6)      Name i               	prefix=| |	suffix=||	indent=||
+(18, 9)      Name j               	prefix=||	suffix=||	indent=||
+(18, 12)     Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(6, 2)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(7, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(14, 2)      Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(6, 2)       Name c               	prefix=||	suffix=||	indent=||
+(8, 2)       TryExcept            	prefix=|  |	suffix=||	indent=|  |
+(12, 2)      Raise                	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 4)       Expr                 	prefix=|    |	suffix=|\n|	indent=|  |
+(10, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=|  |
+(9, 4)       Name d               	prefix=||	suffix=||	indent=|  |
+(11, 4)      Raise                	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 10)     Name e               	prefix=| |	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/sample.out
+++ b/testdata/ast/golden/2.7/sample.out
@@ -1,12 +1,14 @@
 (-1, -1)     Module               	prefix=||	suffix=||	indent=||
 (1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Call                 	prefix=||	suffix=||	indent=||
-(3, 0)       Call                 	prefix=||	suffix=||	indent=||
-(1, 0)       Name repr            	prefix=||	suffix=||	indent=||
+(1, 0)       Name foo             	prefix=||	suffix=||	indent=||
+(1, 4)       Compare              	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 5)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Eq                   	prefix=| |	suffix=| |	indent=||
+(1, 14)      Name c               	prefix=||	suffix=||	indent=||
 (1, 5)       Name a               	prefix=||	suffix=||	indent=||
-(3, 0)       Name repr            	prefix=||	suffix=|  |	indent=||
-(3, 9)       Name b               	prefix=||	suffix=|   |	indent=||
+(1, 8)       Name b               	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/semicolons.out
+++ b/testdata/ast/golden/2.7/semicolons.out
@@ -1,28 +1,28 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|;\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|;  \n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|;|
-(5, 7)       Expr                 	prefix=|   |	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|;|
-(7, 4)       Expr                 	prefix=|  |	suffix=|;\n|
-(9, 0)       If                   	prefix=|\n|	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(3, 0)       Name b               	prefix=||	suffix=| |
-(5, 0)       Name c               	prefix=||	suffix=|  |
-(5, 7)       Name d               	prefix=||	suffix=||
-(7, 0)       Name e               	prefix=||	suffix=||
-(7, 4)       Name f               	prefix=||	suffix=||
-(9, 3)       Name g               	prefix=||	suffix=||
-(9, 6)       Expr                 	prefix=||	suffix=|;|
-(9, 9)       Expr                 	prefix=| |	suffix=|;\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 6)       Name h               	prefix=||	suffix=||
-(9, 9)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|;\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|;  \n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|;|	indent=||
+(5, 7)       Expr                 	prefix=|   |	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|;|	indent=||
+(7, 4)       Expr                 	prefix=|  |	suffix=|;\n|	indent=||
+(9, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(3, 0)       Name b               	prefix=||	suffix=| |	indent=||
+(5, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(5, 7)       Name d               	prefix=||	suffix=||	indent=||
+(7, 0)       Name e               	prefix=||	suffix=||	indent=||
+(7, 4)       Name f               	prefix=||	suffix=||	indent=||
+(9, 3)       Name g               	prefix=||	suffix=||	indent=||
+(9, 6)       Expr                 	prefix=||	suffix=|;|	indent=||
+(9, 9)       Expr                 	prefix=| |	suffix=|;\n|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 6)       Name h               	prefix=||	suffix=||	indent=||
+(9, 9)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/set.out
+++ b/testdata/ast/golden/2.7/set.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Set                  	prefix=||	suffix=||
-(3, 0)       Set                  	prefix=||	suffix=||
-(5, 0)       Set                  	prefix=||	suffix=||
-(7, 0)       Set                  	prefix=||	suffix=||
-(9, 0)       Set                  	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 3)       Name b               	prefix=||	suffix=||
-(1, 5)       Name c               	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=| |
-(5, 1)       Name e               	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=|  |
-(5, 10)      Name g               	prefix=||	suffix=| |
-(7, 1)       Name h               	prefix=||	suffix=||
-(7, 4)       Name i               	prefix=||	suffix=||
-(9, 1)       Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Set                  	prefix=||	suffix=||	indent=||
+(3, 0)       Set                  	prefix=||	suffix=||	indent=||
+(5, 0)       Set                  	prefix=||	suffix=||	indent=||
+(7, 0)       Set                  	prefix=||	suffix=||	indent=||
+(9, 0)       Set                  	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 3)       Name b               	prefix=||	suffix=||	indent=||
+(1, 5)       Name c               	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=| |	indent=||
+(5, 1)       Name e               	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=|  |	indent=||
+(5, 10)      Name g               	prefix=||	suffix=| |	indent=||
+(7, 1)       Name h               	prefix=||	suffix=||	indent=||
+(7, 4)       Name i               	prefix=||	suffix=||	indent=||
+(9, 1)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/slice.out
+++ b/testdata/ast/golden/2.7/slice.out
@@ -1,56 +1,56 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Subscript            	prefix=||	suffix=||
-(3, 0)       Subscript            	prefix=||	suffix=||
-(5, 0)       Subscript            	prefix=||	suffix=||
-(7, 0)       Subscript            	prefix=||	suffix=||
-(9, 0)       Subscript            	prefix=||	suffix=||
-(11, 0)      Subscript            	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=|  |
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=| |
-(-1, -1)     ExtSlice             	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 0)       Name i               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name j               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 0)      Name k               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 6)       Name d               	prefix=||	suffix=||
-(3, 9)       Name e               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Ellipsis             	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 3)       Name None            	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 4)       Name None            	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 5)      Name None            	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 5)       Name g               	prefix=||	suffix=|  |
-(5, 17)      Name h               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(3, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(5, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(7, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(9, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(11, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=| |	indent=||
+(-1, -1)     ExtSlice             	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 0)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 0)      Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 6)       Name d               	prefix=||	suffix=||	indent=||
+(3, 9)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Ellipsis             	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 3)       Name None            	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 4)       Name None            	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 5)      Name None            	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 5)       Name g               	prefix=||	suffix=|  |	indent=||
+(5, 17)      Name h               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/str.out
+++ b/testdata/ast/golden/2.7/str.out
@@ -1,15 +1,15 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Str                  	prefix=||	suffix=||
-(3, 0)       Str                  	prefix=||	suffix=||
-(5, 0)       Str                  	prefix=||	suffix=||
-(7, 0)       Str                  	prefix=||	suffix=||
-(13, -1)     Str                  	prefix=||	suffix=||
-(15, 1)      Str                  	prefix=|(|	suffix=|)|
-(18, 0)      Str                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Str                  	prefix=||	suffix=||	indent=||
+(3, 0)       Str                  	prefix=||	suffix=||	indent=||
+(5, 0)       Str                  	prefix=||	suffix=||	indent=||
+(7, 0)       Str                  	prefix=||	suffix=||	indent=||
+(13, -1)     Str                  	prefix=||	suffix=||	indent=||
+(15, 1)      Str                  	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Str                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/subscript.out
+++ b/testdata/ast/golden/2.7/subscript.out
@@ -1,71 +1,71 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Subscript            	prefix=||	suffix=||
-(3, 0)       Subscript            	prefix=||	suffix=||
-(5, 0)       Subscript            	prefix=||	suffix=||
-(7, 0)       Subscript            	prefix=||	suffix=||
-(9, 0)       Subscript            	prefix=||	suffix=||
-(11, 0)      Subscript            	prefix=||	suffix=||
-(13, 0)      Subscript            	prefix=||	suffix=||
-(15, 1)      Subscript            	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 0)       Name j               	prefix=||	suffix=|  |
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name l               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 0)      Name o               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 0)      Name q               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name r               	prefix=|(|	suffix=|)|
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 2)       Name d               	prefix=||	suffix=||
-(3, 4)       Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 3)       Name g               	prefix=||	suffix=|   |
-(5, 8)       Name h               	prefix=||	suffix=||
-(5, 11)      Name i               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 4)       Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 6)       Name m               	prefix=||	suffix=|  |
-(9, 11)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 3)      Name p               	prefix=||	suffix=|   |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 4)      Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(3, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(5, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(7, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(9, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(11, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(13, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(15, 1)      Subscript            	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 0)       Name j               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 0)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 0)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name r               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 2)       Name d               	prefix=||	suffix=||	indent=||
+(3, 4)       Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 3)       Name g               	prefix=||	suffix=|   |	indent=||
+(5, 8)       Name h               	prefix=||	suffix=||	indent=||
+(5, 11)      Name i               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 4)       Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 6)       Name m               	prefix=||	suffix=|  |	indent=||
+(9, 11)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 3)      Name p               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 4)      Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/trailing_comments.out
+++ b/testdata/ast/golden/2.7/trailing_comments.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|  # a\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|   #   b\n|
-(5, 0)       FunctionDef e        	prefix=|\n|	suffix=||
-(10, 0)      ClassDef i           	prefix=|\n|	suffix=||
-(15, 0)      Assign               	prefix=|\n|	suffix=|  # k\n|
-(1, 0)       Name a               	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=|( |	suffix=| )|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(8, 2)       Expr                 	prefix=|  |	suffix=|   # f\n|
-(5, 0)       Call                 	prefix=||	suffix=||
-(6, 1)       Name d               	prefix=||	suffix=||
-(13, 2)      Return               	prefix=|  |	suffix=|# j\n|
-(10, 1)      Name g               	prefix=||	suffix=||
-(11, 0)      Call                 	prefix=||	suffix=||
-(15, 0)      Name k               	prefix=||	suffix=| |
-(16, 2)      Name l               	prefix=|( # l prefix\n  |	suffix=|   #  l\n)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(8, 2)       Name f               	prefix=||	suffix=||
-(5, 1)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 9)      Name j               	prefix=| |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 1)      Name h               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|  # a\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|   #   b\n|	indent=||
+(5, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      ClassDef i           	prefix=|\n|	suffix=||	indent=||
+(15, 0)      Assign               	prefix=|\n|	suffix=|  # k\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(3, 2)       Name b               	prefix=|( |	suffix=| )|	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|   # f\n|	indent=|  |
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(6, 1)       Name d               	prefix=||	suffix=||	indent=||
+(13, 2)      Return               	prefix=|  |	suffix=|# j\n|	indent=|  |
+(10, 1)      Name g               	prefix=||	suffix=||	indent=||
+(11, 0)      Call                 	prefix=||	suffix=||	indent=||
+(15, 0)      Name k               	prefix=||	suffix=| |	indent=||
+(16, 2)      Name l               	prefix=|( # l prefix\n  |	suffix=|   #  l\n)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(8, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(5, 1)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 9)      Name j               	prefix=| |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 1)      Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/try.out
+++ b/testdata/ast/golden/2.7/try.out
@@ -1,91 +1,91 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       TryExcept            	prefix=||	suffix=||
-(6, 0)       TryExcept            	prefix=|\n|	suffix=||
-(13, 0)      TryFinally           	prefix=|\n|	suffix=||
-(25, 0)      TryExcept            	prefix=|\n|	suffix=||
-(34, 0)      TryFinally           	prefix=|\n|	suffix=||
-(43, 0)      TryFinally           	prefix=|\n|	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(3, 0)       ExceptHandler        	prefix=||	suffix=||
-(7, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 0)       ExceptHandler        	prefix=||	suffix=||
-(11, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(13, 0)      TryExcept            	prefix=|  |	suffix=||
-(22, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(23, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(27, 2)      TryExcept            	prefix=|  # 1\n  |	suffix=||
-(31, 0)      ExceptHandler        	prefix=||	suffix=||
-(36, 2)      TryExcept            	prefix=|  # 2\n  |	suffix=||
-(41, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(45, 2)      TryFinally           	prefix=|  # 3\n  |	suffix=||
-(50, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(2, 2)       Name a               	prefix=||	suffix=||
-(4, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 2)       Name c               	prefix=||	suffix=||
-(8, 7)       Name d               	prefix=| |	suffix=| |
-(8, 12)      Name e               	prefix=||	suffix=|  |
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(11, 2)      Name g               	prefix=||	suffix=||
-(14, 2)      Expr                 	prefix=||	suffix=|\n|
-(15, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 0)      ExceptHandler        	prefix=||	suffix=||
-(19, 0)      ExceptHandler        	prefix=||	suffix=||
-(22, 2)      Name p               	prefix=||	suffix=||
-(23, 2)      Name q               	prefix=||	suffix=||
-(28, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(29, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(32, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(37, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(38, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(41, 2)      Name w               	prefix=||	suffix=||
-(46, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(48, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(50, 2)      Name z               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(4, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(9, 2)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 2)      Name h               	prefix=||	suffix=||
-(15, 2)      Name i               	prefix=||	suffix=||
-(16, 9)      Name j               	prefix=|   |	suffix=|   |
-(16, 19)     Name k               	prefix=||	suffix=||
-(17, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(18, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(19, 8)      Name n               	prefix=|  |	suffix=||
-(20, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(28, 4)      Name r               	prefix=||	suffix=||
-(30, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(32, 2)      Name t               	prefix=||	suffix=||
-(37, 4)      Name u               	prefix=||	suffix=||
-(39, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(46, 4)      Name x               	prefix=||	suffix=||
-(48, 4)      Name y               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(17, 2)      Name l               	prefix=||	suffix=||
-(18, 2)      Name m               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(20, 2)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(30, 4)      Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(39, 4)      Name v               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       TryExcept            	prefix=||	suffix=||	indent=||
+(6, 0)       TryExcept            	prefix=|\n|	suffix=||	indent=||
+(13, 0)      TryFinally           	prefix=|\n|	suffix=||	indent=||
+(25, 0)      TryExcept            	prefix=|\n|	suffix=||	indent=||
+(34, 0)      TryFinally           	prefix=|\n|	suffix=||	indent=||
+(43, 0)      TryFinally           	prefix=|\n|	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(3, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(7, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(8, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(11, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(13, 0)      TryExcept            	prefix=|  |	suffix=||	indent=||
+(22, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(23, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(27, 2)      TryExcept            	prefix=|  # 1\n  |	suffix=||	indent=||
+(31, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(36, 2)      TryExcept            	prefix=|  # 2\n  |	suffix=||	indent=||
+(41, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(45, 2)      TryFinally           	prefix=|  # 3\n  |	suffix=||	indent=||
+(50, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(2, 2)       Name a               	prefix=||	suffix=||	indent=||
+(4, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 2)       Name c               	prefix=||	suffix=||	indent=||
+(8, 7)       Name d               	prefix=| |	suffix=| |	indent=||
+(8, 12)      Name e               	prefix=||	suffix=|  |	indent=||
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(11, 2)      Name g               	prefix=||	suffix=||	indent=|  |
+(14, 2)      Expr                 	prefix=||	suffix=|\n|	indent=||
+(15, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(16, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(19, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(22, 2)      Name p               	prefix=||	suffix=||	indent=|  |
+(23, 2)      Name q               	prefix=||	suffix=||	indent=|  |
+(28, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(29, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=||
+(32, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(37, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(38, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=||
+(41, 2)      Name w               	prefix=||	suffix=||	indent=|  |
+(46, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(48, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(50, 2)      Name z               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(4, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(9, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 2)      Name h               	prefix=||	suffix=||	indent=||
+(15, 2)      Name i               	prefix=||	suffix=||	indent=||
+(16, 9)      Name j               	prefix=|   |	suffix=|   |	indent=||
+(16, 19)     Name k               	prefix=||	suffix=||	indent=||
+(17, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(18, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(19, 8)      Name n               	prefix=|  |	suffix=||	indent=||
+(20, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(28, 4)      Name r               	prefix=||	suffix=||	indent=||
+(30, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(32, 2)      Name t               	prefix=||	suffix=||	indent=|  |
+(37, 4)      Name u               	prefix=||	suffix=||	indent=||
+(39, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(46, 4)      Name x               	prefix=||	suffix=||	indent=||
+(48, 4)      Name y               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(17, 2)      Name l               	prefix=||	suffix=||	indent=|  |
+(18, 2)      Name m               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(20, 2)      Name o               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(30, 4)      Name s               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(39, 4)      Name v               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/try2.out
+++ b/testdata/ast/golden/2.7/try2.out
@@ -1,41 +1,41 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       TryExcept            	prefix=||	suffix=||
-(6, 0)       TryExcept            	prefix=|\n|	suffix=||
-(11, 0)      TryFinally           	prefix=|\n|	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(3, 0)       ExceptHandler        	prefix=||	suffix=||
-(7, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 0)       ExceptHandler        	prefix=||	suffix=||
-(11, 0)      TryExcept            	prefix=|  |	suffix=||
-(16, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(2, 2)       Name a               	prefix=||	suffix=||
-(3, 7)       Name b               	prefix=| |	suffix=||
-(3, 10)      Name c               	prefix=||	suffix=||
-(4, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 2)       Name e               	prefix=||	suffix=||
-(8, 10)      Name d               	prefix=|    |	suffix=|   |
-(8, 15)      Name e               	prefix=||	suffix=||
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(12, 2)      Expr                 	prefix=||	suffix=|\n|
-(13, 0)      ExceptHandler        	prefix=||	suffix=||
-(16, 2)      Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(4, 2)       Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(9, 2)       Name f               	prefix=||	suffix=||
-(12, 2)      Name g               	prefix=||	suffix=||
-(13, 7)      Name h               	prefix=| |	suffix=||
-(13, 10)     Name i               	prefix=||	suffix=||
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(14, 2)      Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       TryExcept            	prefix=||	suffix=||	indent=||
+(6, 0)       TryExcept            	prefix=|\n|	suffix=||	indent=||
+(11, 0)      TryFinally           	prefix=|\n|	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(3, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(7, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(8, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(11, 0)      TryExcept            	prefix=|  |	suffix=||	indent=||
+(16, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(2, 2)       Name a               	prefix=||	suffix=||	indent=||
+(3, 7)       Name b               	prefix=| |	suffix=||	indent=||
+(3, 10)      Name c               	prefix=||	suffix=||	indent=||
+(4, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 2)       Name e               	prefix=||	suffix=||	indent=||
+(8, 10)      Name d               	prefix=|    |	suffix=|   |	indent=||
+(8, 15)      Name e               	prefix=||	suffix=||	indent=||
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(12, 2)      Expr                 	prefix=||	suffix=|\n|	indent=||
+(13, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(16, 2)      Name k               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(4, 2)       Name d               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(9, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(12, 2)      Name g               	prefix=||	suffix=||	indent=||
+(13, 7)      Name h               	prefix=| |	suffix=||	indent=||
+(13, 10)     Name i               	prefix=||	suffix=||	indent=||
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(14, 2)      Name j               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/tuple.out
+++ b/testdata/ast/golden/2.7/tuple.out
@@ -1,61 +1,61 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=||
-(11, 0)      Expr                 	prefix=||	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       Tuple                	prefix=|(|	suffix=|)|
-(3, 0)       Tuple                	prefix=||	suffix=||
-(5, 0)       Tuple                	prefix=||	suffix=||
-(7, 2)       Tuple                	prefix=|( |	suffix=|)|
-(9, 0)       Tuple                	prefix=||	suffix=||
-(11, 1)      Tuple                	prefix=|(|	suffix=| )|
-(13, 1)      Tuple                	prefix=|(|	suffix=|)|
-(15, 1)      Tuple                	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(5, 6)       Name f               	prefix=||	suffix=||
-(5, 8)       Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 2)       Name h               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name i               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 1)      Name j               	prefix=||	suffix=||
-(11, 7)      Tuple                	prefix=|(  |	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(13, 9)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name p               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 7)      Name k               	prefix=||	suffix=||
-(11, 10)     Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Name m               	prefix=||	suffix=||
-(13, 5)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=||	indent=||
+(11, 0)      Expr                 	prefix=||	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(3, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(5, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(7, 2)       Tuple                	prefix=|( |	suffix=|)|	indent=||
+(9, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(11, 1)      Tuple                	prefix=|(|	suffix=| )|	indent=||
+(13, 1)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(15, 1)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(5, 6)       Name f               	prefix=||	suffix=||	indent=||
+(5, 8)       Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 2)       Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name i               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 1)      Name j               	prefix=||	suffix=||	indent=||
+(11, 7)      Tuple                	prefix=|(  |	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 9)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name p               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 7)      Name k               	prefix=||	suffix=||	indent=||
+(11, 10)     Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Name m               	prefix=||	suffix=||	indent=||
+(13, 5)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/unaryop.out
+++ b/testdata/ast/golden/2.7/unaryop.out
@@ -1,21 +1,21 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       UnaryOp              	prefix=||	suffix=||
-(3, 1)       UnaryOp              	prefix=|(|	suffix=|)|
-(5, 0)       UnaryOp              	prefix=||	suffix=||
-(7, 1)       UnaryOp              	prefix=|(|	suffix=|)|
-(-1, -1)     UAdd                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(-1, -1)     USub                 	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Invert               	prefix=||	suffix=|  |
-(5, 3)       Name c               	prefix=||	suffix=||
-(-1, -1)     Not                  	prefix=||	suffix=| |
-(7, 7)       Name d               	prefix=|( |	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       UnaryOp              	prefix=||	suffix=||	indent=||
+(3, 1)       UnaryOp              	prefix=|(|	suffix=|)|	indent=||
+(5, 0)       UnaryOp              	prefix=||	suffix=||	indent=||
+(7, 1)       UnaryOp              	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     UAdd                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     USub                 	prefix=||	suffix=||	indent=||
+(3, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Invert               	prefix=||	suffix=|  |	indent=||
+(5, 3)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Not                  	prefix=||	suffix=| |	indent=||
+(7, 7)       Name d               	prefix=|( |	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/while.out
+++ b/testdata/ast/golden/2.7/while.out
@@ -1,19 +1,19 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       While                	prefix=||	suffix=||
-(5, 0)       While                	prefix=|\n|	suffix=||
-(1, 6)       Name True            	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(3, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(5, 6)       Name True            	prefix=||	suffix=||
-(6, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name a               	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(6, 2)       Name c               	prefix=||	suffix=||
-(8, 2)       Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       While                	prefix=||	suffix=||	indent=||
+(5, 0)       While                	prefix=|\n|	suffix=||	indent=||
+(1, 6)       Name True            	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(3, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(5, 6)       Name True            	prefix=||	suffix=||	indent=||
+(6, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name a               	prefix=||	suffix=||	indent=|  |
+(3, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(6, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name d               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/with.out
+++ b/testdata/ast/golden/2.7/with.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 5)       With                 	prefix=||	suffix=||
-(4, 8)       With                 	prefix=|\n|	suffix=||
-(7, 5)       With                 	prefix=|\n|	suffix=||
-(1, 5)       Name a               	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(4, 8)       Name c               	prefix=||	suffix=|   |
-(4, 18)      Name d               	prefix=||	suffix=|       |
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 5)       Name e               	prefix=||	suffix=||
-(7, 8)       With                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(5, 2)       Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 8)       Name f               	prefix=||	suffix=| |
-(7, 13)      Name g               	prefix=||	suffix=||
-(8, 7)       With                 	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(8, 7)       Name h               	prefix=||	suffix=| |
-(8, 12)      Name i               	prefix=||	suffix=||
-(9, 4)       Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(9, 4)       Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 5)       With                 	prefix=||	suffix=||	indent=||
+(4, 8)       With                 	prefix=|\n|	suffix=||	indent=||
+(7, 5)       With                 	prefix=|\n|	suffix=||	indent=||
+(1, 5)       Name a               	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 8)       Name c               	prefix=||	suffix=|   |	indent=||
+(4, 18)      Name d               	prefix=||	suffix=|       |	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 5)       Name e               	prefix=||	suffix=||	indent=||
+(7, 8)       With                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(5, 2)       Name e               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 8)       Name f               	prefix=||	suffix=| |	indent=||
+(7, 13)      Name g               	prefix=||	suffix=||	indent=||
+(8, 7)       With                 	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(8, 7)       Name h               	prefix=||	suffix=| |	indent=|  |
+(8, 12)      Name i               	prefix=||	suffix=||	indent=|  |
+(9, 4)       Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(9, 4)       Name j               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/assert.out
+++ b/testdata/ast/golden/3.4/assert.out
@@ -1,12 +1,12 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Assert               	prefix=||	suffix=|\n|
-(3, 0)       Assert               	prefix=|\n|	suffix=|\n|
-(5, 0)       Assert               	prefix=|\n|	suffix=|\n|
-(1, 7)       Name a               	prefix=| |	suffix=||
-(3, 8)       Name b               	prefix=| (|	suffix=|)|
-(5, 9)       Name c               	prefix=|   |	suffix=|  |
-(5, 15)      Name d               	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Assert               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Assert               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Assert               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 7)       Name a               	prefix=| |	suffix=||	indent=||
+(3, 8)       Name b               	prefix=| (|	suffix=|)|	indent=||
+(5, 9)       Name c               	prefix=|   |	suffix=|  |	indent=||
+(5, 15)      Name d               	prefix=|  |	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/assign.out
+++ b/testdata/ast/golden/3.4/assign.out
@@ -1,20 +1,20 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Assign               	prefix=||	suffix=|\n|
-(3, 0)       Assign               	prefix=|\n|	suffix=|\n|
-(5, 0)       Assign               	prefix=|\n|	suffix=|\n|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=| |
-(3, 9)       Name e               	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=||
-(5, 2)       Name g               	prefix=||	suffix=|  |
-(5, 8)       Name h               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Assign               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Assign               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Assign               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=| |	indent=||
+(3, 9)       Name e               	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=||	indent=||
+(5, 2)       Name g               	prefix=||	suffix=|  |	indent=||
+(5, 8)       Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/attribute.out
+++ b/testdata/ast/golden/3.4/attribute.out
@@ -1,16 +1,16 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Attribute b          	prefix=||	suffix=||
-(3, 0)       Attribute d          	prefix=||	suffix=||
-(5, 2)       Attribute f          	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name e               	prefix=|( |	suffix=| )|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Attribute b          	prefix=||	suffix=||	indent=||
+(3, 0)       Attribute d          	prefix=||	suffix=||	indent=||
+(5, 2)       Attribute f          	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name e               	prefix=|( |	suffix=| )|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/augassign.out
+++ b/testdata/ast/golden/3.4/augassign.out
@@ -1,20 +1,20 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       AugAssign            	prefix=||	suffix=|\n|
-(3, 0)       AugAssign            	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=||
-(1, 5)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(-1, -1)     Sub                  	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=||
-(5, 0)       Compare              	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=|   |
-(-1, -1)     LtE                  	prefix=||	suffix=|  |
-(5, 8)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       AugAssign            	prefix=||	suffix=|\n|	indent=||
+(3, 0)       AugAssign            	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=||	indent=||
+(1, 5)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Sub                  	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Compare              	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     LtE                  	prefix=||	suffix=|  |	indent=||
+(5, 8)       Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/binop.out
+++ b/testdata/ast/golden/3.4/binop.out
@@ -1,71 +1,71 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       BinOp                	prefix=||	suffix=||
-(3, 0)       BinOp                	prefix=||	suffix=||
-(5, 0)       BinOp                	prefix=||	suffix=||
-(7, 0)       BinOp                	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(12, 4)      BinOp                	prefix=|(\n    |	suffix=|\n)|
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(-1, -1)     Sub                  	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(-1, -1)     Div                  	prefix=||	suffix=| |
-(5, 4)       Name f               	prefix=||	suffix=||
-(7, 0)       Name g               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(7, 5)       BinOp                	prefix=|(|	suffix=|)|
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     BitOr                	prefix=||	suffix=||
-(9, 25)      BinOp                	prefix=||	suffix=||
-(12, 4)      Name a               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(12, 8)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 5)       Name h               	prefix=||	suffix=| |
-(-1, -1)     Add                  	prefix=||	suffix=| |
-(7, 9)       Name i               	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     BitAnd               	prefix=||	suffix=||
-(9, 22)      Name o               	prefix=||	suffix=| |
-(9, 25)      Name p               	prefix=||	suffix=| |
-(-1, -1)     RShift               	prefix=||	suffix=|  |
-(9, 31)      Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=| |
-(-1, -1)     LShift               	prefix=||	suffix=|  |
-(9, 19)      Name n               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       BinOp                	prefix=||	suffix=||
-(-1, -1)     Add                  	prefix=||	suffix=||
-(9, 8)       BinOp                	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name j               	prefix=||	suffix=||
-(-1, -1)     FloorDiv             	prefix=||	suffix=||
-(9, 3)       Name k               	prefix=||	suffix=|  |
-(9, 8)       Name l               	prefix=||	suffix=| |
-(-1, -1)     BitXor               	prefix=||	suffix=||
-(9, 11)      Name m               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(3, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(5, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(7, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(12, 4)      BinOp                	prefix=|(\n    |	suffix=|\n)|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Sub                  	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Div                  	prefix=||	suffix=| |	indent=||
+(5, 4)       Name f               	prefix=||	suffix=||	indent=||
+(7, 0)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(7, 5)       BinOp                	prefix=|(|	suffix=|)|	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     BitOr                	prefix=||	suffix=||	indent=||
+(9, 25)      BinOp                	prefix=||	suffix=||	indent=||
+(12, 4)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(12, 8)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 5)       Name h               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=| |	indent=||
+(7, 9)       Name i               	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     BitAnd               	prefix=||	suffix=||	indent=||
+(9, 22)      Name o               	prefix=||	suffix=| |	indent=||
+(9, 25)      Name p               	prefix=||	suffix=| |	indent=||
+(-1, -1)     RShift               	prefix=||	suffix=|  |	indent=||
+(9, 31)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=| |	indent=||
+(-1, -1)     LShift               	prefix=||	suffix=|  |	indent=||
+(9, 19)      Name n               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       BinOp                	prefix=||	suffix=||	indent=||
+(-1, -1)     Add                  	prefix=||	suffix=||	indent=||
+(9, 8)       BinOp                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     FloorDiv             	prefix=||	suffix=||	indent=||
+(9, 3)       Name k               	prefix=||	suffix=|  |	indent=||
+(9, 8)       Name l               	prefix=||	suffix=| |	indent=||
+(-1, -1)     BitXor               	prefix=||	suffix=||	indent=||
+(9, 11)      Name m               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/boolop.out
+++ b/testdata/ast/golden/3.4/boolop.out
@@ -1,54 +1,54 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       BoolOp               	prefix=||	suffix=||
-(3, 0)       BoolOp               	prefix=||	suffix=||
-(5, 0)       BoolOp               	prefix=||	suffix=||
-(7, 0)       BoolOp               	prefix=||	suffix=||
-(9, 0)       BoolOp               	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 6)       Name b               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(3, 5)       Name d               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(5, 1)       BoolOp               	prefix=|(|	suffix=|)|
-(5, 20)      Name h               	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(7, 0)       BoolOp               	prefix=||	suffix=||
-(7, 20)      Name k               	prefix=|(|	suffix=|)|
-(-1, -1)     Or                   	prefix=||	suffix=||
-(9, 0)       BoolOp               	prefix=||	suffix=||
-(9, 29)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(5, 1)       Name e               	prefix=||	suffix=| |
-(5, 8)       BoolOp               	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(7, 1)       Name i               	prefix=|(|	suffix=|)|
-(7, 11)      Name j               	prefix=||	suffix=|   |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     And                  	prefix=||	suffix=||
-(9, 0)       Name l               	prefix=||	suffix=| |
-(9, 8)       Name m               	prefix=||	suffix=|        |
-(9, 22)      Name n               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Or                   	prefix=||	suffix=||
-(5, 8)       Name f               	prefix=||	suffix=| |
-(5, 13)      Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(3, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(5, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(7, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(9, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 6)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(3, 5)       Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(5, 1)       BoolOp               	prefix=|(|	suffix=|)|	indent=||
+(5, 20)      Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(7, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(7, 20)      Name k               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(9, 0)       BoolOp               	prefix=||	suffix=||	indent=||
+(9, 29)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(5, 1)       Name e               	prefix=||	suffix=| |	indent=||
+(5, 8)       BoolOp               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(7, 1)       Name i               	prefix=|(|	suffix=|)|	indent=||
+(7, 11)      Name j               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     And                  	prefix=||	suffix=||	indent=||
+(9, 0)       Name l               	prefix=||	suffix=| |	indent=||
+(9, 8)       Name m               	prefix=||	suffix=|        |	indent=||
+(9, 22)      Name n               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Or                   	prefix=||	suffix=||	indent=||
+(5, 8)       Name f               	prefix=||	suffix=| |	indent=||
+(5, 13)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/call.out
+++ b/testdata/ast/golden/3.4/call.out
@@ -1,60 +1,60 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Call                 	prefix=||	suffix=||
-(3, 0)       Call                 	prefix=||	suffix=||
-(5, 0)       Call                 	prefix=||	suffix=||
-(7, 0)       Call                 	prefix=||	suffix=||
-(9, 1)       Call                 	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(3, 2)       Name d               	prefix=||	suffix=||
-(3, 5)       Name e               	prefix=||	suffix=||
-(-1, -1)     keyword f            	prefix=||	suffix=||
-(3, 14)      Name args            	prefix=||	suffix=||
-(3, 22)      Name kwargs          	prefix=||	suffix=||
-(5, 0)       Name h               	prefix=||	suffix=|  |
-(5, 6)       Name i               	prefix=||	suffix=| |
-(-1, -1)     keyword k            	prefix=||	suffix=||
-(-1, -1)     keyword m            	prefix=||	suffix=||
-(5, 13)      Name j               	prefix=|  |	suffix=|   |
-(5, 33)      Name o               	prefix=||	suffix=||
-(7, 0)       Name p               	prefix=||	suffix=||
-(7, 2)       Name q               	prefix=||	suffix=||
-(7, 5)       Name r               	prefix=||	suffix=||
-(-1, -1)     keyword s            	prefix=||	suffix=||
-(-1, -1)     keyword u            	prefix=||	suffix=||
-(9, 1)       Name q               	prefix=|(|	suffix=|)|
-(9, 4)       Name r               	prefix=||	suffix=||
-(9, 7)       Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 10)      Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 22)      Name l               	prefix=| |	suffix=||
-(5, 27)      Name n               	prefix=| |	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 10)      Name t               	prefix=||	suffix=||
-(7, 16)      Name v               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Call                 	prefix=||	suffix=||	indent=||
+(3, 0)       Call                 	prefix=||	suffix=||	indent=||
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(7, 0)       Call                 	prefix=||	suffix=||	indent=||
+(9, 1)       Call                 	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(3, 2)       Name d               	prefix=||	suffix=||	indent=||
+(3, 5)       Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword f            	prefix=||	suffix=||	indent=||
+(3, 14)      Name args            	prefix=||	suffix=||	indent=||
+(3, 22)      Name kwargs          	prefix=||	suffix=||	indent=||
+(5, 0)       Name h               	prefix=||	suffix=|  |	indent=||
+(5, 6)       Name i               	prefix=||	suffix=| |	indent=||
+(-1, -1)     keyword k            	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword m            	prefix=||	suffix=||	indent=||
+(5, 13)      Name j               	prefix=|  |	suffix=|   |	indent=||
+(5, 33)      Name o               	prefix=||	suffix=||	indent=||
+(7, 0)       Name p               	prefix=||	suffix=||	indent=||
+(7, 2)       Name q               	prefix=||	suffix=||	indent=||
+(7, 5)       Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword s            	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword u            	prefix=||	suffix=||	indent=||
+(9, 1)       Name q               	prefix=|(|	suffix=|)|	indent=||
+(9, 4)       Name r               	prefix=||	suffix=||	indent=||
+(9, 7)       Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 10)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 22)      Name l               	prefix=| |	suffix=||	indent=||
+(5, 27)      Name n               	prefix=| |	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 10)      Name t               	prefix=||	suffix=||	indent=||
+(7, 16)      Name v               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/classdef.out
+++ b/testdata/ast/golden/3.4/classdef.out
@@ -1,26 +1,26 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       ClassDef a           	prefix=||	suffix=||
-(4, 0)       ClassDef d           	prefix=|\n|	suffix=||
-(9, 0)       ClassDef g           	prefix=|\n|	suffix=||
-(12, 0)      ClassDef h           	prefix=|\n|	suffix=||
-(15, 0)      ClassDef i           	prefix=|\n|	suffix=||
-(1, 8)       Name object          	prefix=||	suffix=||
-(2, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(6, 15)      Name e               	prefix=||	suffix=| |
-(6, 20)      Name f               	prefix=|  |	suffix=||
-(7, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(4, 1)       Name b               	prefix=||	suffix=||
-(5, 0)       Call                 	prefix=||	suffix=||
-(10, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(13, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(15, 8)      Name j               	prefix=||	suffix=||
-(15, 11)     Name k               	prefix=| |	suffix=||
-(16, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 1)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       ClassDef a           	prefix=||	suffix=||	indent=||
+(4, 0)       ClassDef d           	prefix=|\n|	suffix=||	indent=||
+(9, 0)       ClassDef g           	prefix=|\n|	suffix=||	indent=||
+(12, 0)      ClassDef h           	prefix=|\n|	suffix=||	indent=||
+(15, 0)      ClassDef i           	prefix=|\n|	suffix=||	indent=||
+(1, 8)       Name object          	prefix=||	suffix=||	indent=||
+(2, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(6, 15)      Name e               	prefix=||	suffix=| |	indent=||
+(6, 20)      Name f               	prefix=|  |	suffix=||	indent=||
+(7, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 1)       Name b               	prefix=||	suffix=||	indent=||
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(10, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(13, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(15, 8)      Name j               	prefix=||	suffix=||	indent=||
+(15, 11)     Name k               	prefix=| |	suffix=||	indent=||
+(16, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 1)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/compare.out
+++ b/testdata/ast/golden/3.4/compare.out
@@ -1,53 +1,53 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Compare              	prefix=||	suffix=||
-(3, 0)       Compare              	prefix=||	suffix=||
-(5, 0)       Compare              	prefix=||	suffix=||
-(7, 0)       Compare              	prefix=||	suffix=||
-(9, 1)       Compare              	prefix=|(|	suffix=|)|
-(11, 0)      Compare              	prefix=||	suffix=||
-(13, 0)      Compare              	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=| |
-(-1, -1)     Lt                   	prefix=||	suffix=| |
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=| |
-(-1, -1)     Gt                   	prefix=||	suffix=| |
-(3, 4)       Name d               	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(-1, -1)     GtE                  	prefix=||	suffix=|  |
-(-1, -1)     Lt                   	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=||
-(5, 8)       Name g               	prefix=||	suffix=||
-(7, 0)       Name h               	prefix=||	suffix=|  |
-(-1, -1)     NotIn                	prefix=||	suffix=|  |
-(7, 11)      Name j               	prefix=||	suffix=||
-(9, 1)       Name i               	prefix=||	suffix=|  |
-(-1, -1)     IsNot                	prefix=||	suffix=| |
-(9, 13)      Name k               	prefix=||	suffix=||
-(11, 0)      Name l               	prefix=||	suffix=|   |
-(-1, -1)     Is                   	prefix=||	suffix=| |
-(11, 7)      Name m               	prefix=||	suffix=||
-(13, 0)      Name n               	prefix=||	suffix=|  |
-(-1, -1)     In                   	prefix=||	suffix=| |
-(13, 6)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Compare              	prefix=||	suffix=||	indent=||
+(3, 0)       Compare              	prefix=||	suffix=||	indent=||
+(5, 0)       Compare              	prefix=||	suffix=||	indent=||
+(7, 0)       Compare              	prefix=||	suffix=||	indent=||
+(9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
+(11, 0)      Compare              	prefix=||	suffix=||	indent=||
+(13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Lt                   	prefix=||	suffix=| |	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Gt                   	prefix=||	suffix=| |	indent=||
+(3, 4)       Name d               	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     GtE                  	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=||	indent=||
+(5, 8)       Name g               	prefix=||	suffix=||	indent=||
+(7, 0)       Name h               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     NotIn                	prefix=||	suffix=|  |	indent=||
+(7, 11)      Name j               	prefix=||	suffix=||	indent=||
+(9, 1)       Name i               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     IsNot                	prefix=||	suffix=| |	indent=||
+(9, 13)      Name k               	prefix=||	suffix=||	indent=||
+(11, 0)      Name l               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Is                   	prefix=||	suffix=| |	indent=||
+(11, 7)      Name m               	prefix=||	suffix=||	indent=||
+(13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     In                   	prefix=||	suffix=| |	indent=||
+(13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/compexps.out
+++ b/testdata/ast/golden/3.4/compexps.out
@@ -1,108 +1,108 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       SetComp              	prefix=||	suffix=||
-(3, 3)       SetComp              	prefix=||	suffix=||
-(5, 1)       SetComp              	prefix=||	suffix=||
-(7, 1)       ListComp             	prefix=||	suffix=||
-(9, 3)       ListComp             	prefix=||	suffix=||
-(11, 1)      ListComp             	prefix=||	suffix=||
-(13, 1)      GeneratorExp         	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(5, 1)       Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(7, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(9, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(11, 1)      Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 7)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 17)      Name c               	prefix=||	suffix=|    |
-(3, 26)      Name d               	prefix=||	suffix=|    |
-(3, 40)      Name e               	prefix=||	suffix=|  |
-(3, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 7)       Name g               	prefix=||	suffix=| |
-(5, 12)      Name h               	prefix=||	suffix=| |
-(5, 17)      Name i               	prefix=||	suffix=| |
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 28)      Name k               	prefix=||	suffix=| |
-(5, 33)      Name l               	prefix=||	suffix=| |
-(5, 39)      Name m               	prefix=||	suffix=| |
-(5, 44)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 7)       Name a               	prefix=||	suffix=| |
-(7, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 17)      Name c               	prefix=||	suffix=|    |
-(9, 26)      Name d               	prefix=||	suffix=|    |
-(9, 40)      Name e               	prefix=||	suffix=|  |
-(9, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 7)      Name g               	prefix=||	suffix=| |
-(11, 12)     Name h               	prefix=||	suffix=| |
-(11, 17)     Name i               	prefix=||	suffix=| |
-(11, 22)     Name j               	prefix=||	suffix=| |
-(11, 28)     Name k               	prefix=||	suffix=| |
-(11, 33)     Name l               	prefix=||	suffix=| |
-(11, 39)     Name m               	prefix=||	suffix=| |
-(11, 44)     Name o               	prefix=||	suffix=||
-(13, 2)      Name p               	prefix=||	suffix=||
-(13, 5)      Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 12)     Tuple                	prefix=||	suffix=||
-(13, 20)     Name r               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 12)     Name p               	prefix=||	suffix=||
-(13, 15)     Name q               	prefix=||	suffix=| |
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       SetComp              	prefix=||	suffix=||	indent=||
+(3, 3)       SetComp              	prefix=||	suffix=||	indent=||
+(5, 1)       SetComp              	prefix=||	suffix=||	indent=||
+(7, 1)       ListComp             	prefix=||	suffix=||	indent=||
+(9, 3)       ListComp             	prefix=||	suffix=||	indent=||
+(11, 1)      ListComp             	prefix=||	suffix=||	indent=||
+(13, 1)      GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(5, 1)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(7, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(9, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(11, 1)      Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(3, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(3, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(3, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 7)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name h               	prefix=||	suffix=| |	indent=||
+(5, 17)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 28)      Name k               	prefix=||	suffix=| |	indent=||
+(5, 33)      Name l               	prefix=||	suffix=| |	indent=||
+(5, 39)      Name m               	prefix=||	suffix=| |	indent=||
+(5, 44)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(7, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(9, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(9, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(9, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 7)      Name g               	prefix=||	suffix=| |	indent=||
+(11, 12)     Name h               	prefix=||	suffix=| |	indent=||
+(11, 17)     Name i               	prefix=||	suffix=| |	indent=||
+(11, 22)     Name j               	prefix=||	suffix=| |	indent=||
+(11, 28)     Name k               	prefix=||	suffix=| |	indent=||
+(11, 33)     Name l               	prefix=||	suffix=| |	indent=||
+(11, 39)     Name m               	prefix=||	suffix=| |	indent=||
+(11, 44)     Name o               	prefix=||	suffix=||	indent=||
+(13, 2)      Name p               	prefix=||	suffix=||	indent=||
+(13, 5)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 12)     Tuple                	prefix=||	suffix=||	indent=||
+(13, 20)     Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 12)     Name p               	prefix=||	suffix=||	indent=||
+(13, 15)     Name q               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/del.out
+++ b/testdata/ast/golden/3.4/del.out
@@ -1,16 +1,16 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Delete               	prefix=||	suffix=|\n|
-(3, 0)       Delete               	prefix=|\n|	suffix=|\n|
-(5, 0)       Delete               	prefix=|\n|	suffix=|\n|
-(1, 4)       Name a               	prefix=||	suffix=||
-(3, 4)       Name b               	prefix=||	suffix=||
-(3, 7)       Name c               	prefix=||	suffix=||
-(5, 7)       Name d               	prefix=||	suffix=|  |
-(5, 11)      Name e               	prefix=||	suffix=|   |
-(5, 22)      Name f               	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
-(-1, -1)     Del                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Delete               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Delete               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Delete               	prefix=|\n|	suffix=|\n|	indent=||
+(1, 4)       Name a               	prefix=||	suffix=||	indent=||
+(3, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 7)       Name c               	prefix=||	suffix=||	indent=||
+(5, 7)       Name d               	prefix=||	suffix=|  |	indent=||
+(5, 11)      Name e               	prefix=||	suffix=|   |	indent=||
+(5, 22)      Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Del                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/dict.out
+++ b/testdata/ast/golden/3.4/dict.out
@@ -1,57 +1,57 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(10, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Dict                 	prefix=||	suffix=||
-(3, 0)       Dict                 	prefix=||	suffix=||
-(5, 0)       Dict                 	prefix=||	suffix=||
-(10, 0)      Dict                 	prefix=||	suffix=||
-(15, 0)      Dict                 	prefix=||	suffix=||
-(19, 0)      Dict                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=|  |	suffix=||
-(3, 9)       Name e               	prefix=||	suffix=||
-(3, 15)      Name g               	prefix=||	suffix=|   |
-(3, 6)       Name d               	prefix=||	suffix=||
-(3, 11)      Name f               	prefix=||	suffix=||
-(3, 22)      Name h               	prefix=||	suffix=|   |
-(6, 3)       Name i               	prefix=|\n   |	suffix=||
-(7, 1)       Name k               	prefix=||	suffix=|    |
-(8, 1)       Name n               	prefix=||	suffix=||
-(8, 6)       Name p               	prefix=||	suffix=||
-(6, 7)       Name j               	prefix=||	suffix=||
-(7, 11)      Name l               	prefix=||	suffix=|   |
-(8, 3)       Name o               	prefix=||	suffix=||
-(8, 8)       Name q               	prefix=||	suffix=|   |
-(11, 3)      Name r               	prefix=|\n   |	suffix=||
-(12, 3)      Name t               	prefix=||	suffix=||
-(11, 6)      Name s               	prefix=||	suffix=||
-(12, 6)      Name u               	prefix=||	suffix=||
-(19, 1)      Name w               	prefix=||	suffix=||
-(19, 4)      Name x               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(10, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(3, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(5, 0)       Dict                 	prefix=||	suffix=||	indent=||
+(10, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(15, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(19, 0)      Dict                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=|  |	suffix=||	indent=||
+(3, 9)       Name e               	prefix=||	suffix=||	indent=||
+(3, 15)      Name g               	prefix=||	suffix=|   |	indent=||
+(3, 6)       Name d               	prefix=||	suffix=||	indent=||
+(3, 11)      Name f               	prefix=||	suffix=||	indent=||
+(3, 22)      Name h               	prefix=||	suffix=|   |	indent=||
+(6, 3)       Name i               	prefix=|\n   |	suffix=||	indent=||
+(7, 1)       Name k               	prefix=||	suffix=|    |	indent=||
+(8, 1)       Name n               	prefix=||	suffix=||	indent=||
+(8, 6)       Name p               	prefix=||	suffix=||	indent=||
+(6, 7)       Name j               	prefix=||	suffix=||	indent=||
+(7, 11)      Name l               	prefix=||	suffix=|   |	indent=||
+(8, 3)       Name o               	prefix=||	suffix=||	indent=||
+(8, 8)       Name q               	prefix=||	suffix=|   |	indent=||
+(11, 3)      Name r               	prefix=|\n   |	suffix=||	indent=||
+(12, 3)      Name t               	prefix=||	suffix=||	indent=||
+(11, 6)      Name s               	prefix=||	suffix=||	indent=||
+(12, 6)      Name u               	prefix=||	suffix=||	indent=||
+(19, 1)      Name w               	prefix=||	suffix=||	indent=||
+(19, 4)      Name x               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/dictcomp.out
+++ b/testdata/ast/golden/3.4/dictcomp.out
@@ -1,28 +1,28 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       DictComp             	prefix=||	suffix=||
-(3, 3)       DictComp             	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name e               	prefix=||	suffix=||
-(3, 5)       Name f               	prefix=||	suffix=|   |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 10)      Name c               	prefix=||	suffix=| |
-(1, 15)      Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(4, 2)       Name h               	prefix=||	suffix=| |
-(4, 9)       Name i               	prefix=||	suffix=|   |
-(4, 19)      Name j               	prefix=||	suffix=| |
-(4, 26)      Name k               	prefix=||	suffix=| |
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       DictComp             	prefix=||	suffix=||	indent=||
+(3, 3)       DictComp             	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name e               	prefix=||	suffix=||	indent=||
+(3, 5)       Name f               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 10)      Name c               	prefix=||	suffix=| |	indent=||
+(1, 15)      Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(4, 2)       Name h               	prefix=||	suffix=| |	indent=||
+(4, 9)       Name i               	prefix=||	suffix=|   |	indent=||
+(4, 19)      Name j               	prefix=||	suffix=| |	indent=||
+(4, 26)      Name k               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/ellipsis.out
+++ b/testdata/ast/golden/3.4/ellipsis.out
@@ -1,5 +1,5 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=||
-(2, 2)       Ellipsis             	prefix=||	suffix=|\n|
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=||	indent=|  |
+(2, 2)       Ellipsis             	prefix=||	suffix=|\n|	indent=|  |

--- a/testdata/ast/golden/3.4/empty.out
+++ b/testdata/ast/golden/3.4/empty.out
@@ -1,1 +1,1 @@
-(-1, -1)     Module               	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/for.out
+++ b/testdata/ast/golden/3.4/for.out
@@ -1,26 +1,26 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       For                  	prefix=||	suffix=||
-(4, 0)       For                  	prefix=|\n|	suffix=||
-(1, 4)       Name a               	prefix=||	suffix=| |
-(1, 9)       Name b               	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(4, 6)       Name d               	prefix=||	suffix=|    |
-(4, 21)      Name e               	prefix=||	suffix=|   |
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(6, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name c               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name f               	prefix=||	suffix=||
-(6, 2)       Name g               	prefix=||	suffix=||
-(8, 2)       Name h               	prefix=||	suffix=||
-(9, 2)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       For                  	prefix=||	suffix=||	indent=||
+(4, 0)       For                  	prefix=|\n|	suffix=||	indent=||
+(1, 4)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 9)       Name b               	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 6)       Name d               	prefix=||	suffix=|    |	indent=||
+(4, 21)      Name e               	prefix=||	suffix=|   |	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(6, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(6, 2)       Name g               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name h               	prefix=||	suffix=||	indent=|  |
+(9, 2)       Name i               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/fromimport.out
+++ b/testdata/ast/golden/3.4/fromimport.out
@@ -1,15 +1,15 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       ImportFrom a         	prefix=||	suffix=|\n|
-(3, 0)       ImportFrom c         	prefix=|\n|	suffix=|\n|
-(5, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|
-(7, 0)       ImportFrom g.h.i     	prefix=|\n|	suffix=|\n|
-(9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|
-(11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|
-(13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|
-(-1, -1)     alias b              	prefix=| |	suffix=||
-(-1, -1)     alias d              	prefix=| |	suffix=||
-(-1, -1)     alias f              	prefix=| |	suffix=||
-(-1, -1)     alias j              	prefix=| |	suffix=||
-(-1, -1)     alias l              	prefix=| |	suffix=||
-(-1, -1)     alias n              	prefix=||	suffix=||
-(-1, -1)     alias p              	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       ImportFrom a         	prefix=||	suffix=|\n|	indent=||
+(3, 0)       ImportFrom c         	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       ImportFrom g.h.i     	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(-1, -1)     alias b              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias d              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias f              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias j              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias l              	prefix=| |	suffix=||	indent=||
+(-1, -1)     alias n              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias p              	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/functiondef.out
+++ b/testdata/ast/golden/3.4/functiondef.out
@@ -1,77 +1,77 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(4, 0)       FunctionDef d        	prefix=|\n|	suffix=||
-(7, 0)       FunctionDef k        	prefix=|\n|	suffix=||
-(12, 0)      FunctionDef v        	prefix=|\n|	suffix=||
-(18, 0)      FunctionDef x        	prefix=|\n|	suffix=||
-(21, 0)      ClassDef A           	prefix=|\n|	suffix=||
-(27, 0)      FunctionDef f        	prefix=|\n|	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(10, 2)      Return               	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(16, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(12, 0)      Call                 	prefix=||	suffix=||
-(13, 1)      Name p               	prefix=||	suffix=||
-(14, 1)      Call                 	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(19, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(22, 2)      FunctionDef d        	prefix=|  |	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=|\n    |
-(30, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(1, 6)       arg b                	prefix=||	suffix=||
-(2, 2)       Name c               	prefix=||	suffix=||
-(4, 13)      arg e                	prefix=||	suffix=|  |
-(4, 17)      arg f                	prefix=||	suffix=||
-(4, 24)      arg h                	prefix=||	suffix=||
-(4, 31)      arg i                	prefix=||	suffix=| |
-(4, 20)      Name g               	prefix=||	suffix=||
-(5, 2)       Name j               	prefix=||	suffix=||
-(8, 2)       Name l               	prefix=||	suffix=||
-(9, 2)       Name m               	prefix=||	suffix=||
-(10, 9)      Name n               	prefix=| |	suffix=||
-(16, 2)      Name w               	prefix=||	suffix=||
-(12, 1)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 1)      Name q               	prefix=||	suffix=||
-(14, 3)      Name r               	prefix=||	suffix=||
-(14, 6)      Name s               	prefix=||	suffix=||
-(-1, -1)     keyword t            	prefix=||	suffix=||
-(18, 6)      arg y                	prefix=||	suffix=||
-(18, 9)      arg z                	prefix=||	suffix=||
-(18, 11)     Name a               	prefix=||	suffix=||
-(19, 2)      Name b               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(25, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(22, 3)      Name b               	prefix=||	suffix=||
-(23, 3)      Name c               	prefix=||	suffix=||
-(28, 4)      arg g                	prefix=||	suffix=||
-(28, 7)      arg h                	prefix=||	suffix=||
-(28, 9)      Name i               	prefix=||	suffix=||
-(30, 2)      Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 11)     Name u               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(25, 4)      Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(4, 0)       FunctionDef d        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef k        	prefix=|\n|	suffix=||	indent=||
+(12, 0)      FunctionDef v        	prefix=|\n|	suffix=||	indent=||
+(18, 0)      FunctionDef x        	prefix=|\n|	suffix=||	indent=||
+(21, 0)      ClassDef A           	prefix=|\n|	suffix=||	indent=||
+(27, 0)      FunctionDef f        	prefix=|\n|	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(10, 2)      Return               	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(16, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(12, 0)      Call                 	prefix=||	suffix=||	indent=||
+(13, 1)      Name p               	prefix=||	suffix=||	indent=||
+(14, 1)      Call                 	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(19, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(22, 2)      FunctionDef d        	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=|\n    |	indent=||
+(30, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(1, 6)       arg b                	prefix=||	suffix=||	indent=||
+(2, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(4, 13)      arg e                	prefix=||	suffix=|  |	indent=||
+(4, 17)      arg f                	prefix=||	suffix=||	indent=||
+(4, 24)      arg h                	prefix=||	suffix=||	indent=||
+(4, 31)      arg i                	prefix=||	suffix=| |	indent=||
+(4, 20)      Name g               	prefix=||	suffix=||	indent=||
+(5, 2)       Name j               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name l               	prefix=||	suffix=||	indent=|  |
+(9, 2)       Name m               	prefix=||	suffix=||	indent=|  |
+(10, 9)      Name n               	prefix=| |	suffix=||	indent=|  |
+(16, 2)      Name w               	prefix=||	suffix=||	indent=|  |
+(12, 1)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 1)      Name q               	prefix=||	suffix=||	indent=||
+(14, 3)      Name r               	prefix=||	suffix=||	indent=||
+(14, 6)      Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     keyword t            	prefix=||	suffix=||	indent=||
+(18, 6)      arg y                	prefix=||	suffix=||	indent=||
+(18, 9)      arg z                	prefix=||	suffix=||	indent=||
+(18, 11)     Name a               	prefix=||	suffix=||	indent=||
+(19, 2)      Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=|  |
+(25, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(22, 3)      Name b               	prefix=||	suffix=||	indent=|  |
+(23, 3)      Name c               	prefix=||	suffix=||	indent=|  |
+(28, 4)      arg g                	prefix=||	suffix=||	indent=||
+(28, 7)      arg h                	prefix=||	suffix=||	indent=||
+(28, 9)      Name i               	prefix=||	suffix=||	indent=||
+(30, 2)      Name j               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 11)     Name u               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(25, 4)      Name e               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/generators.out
+++ b/testdata/ast/golden/3.4/generators.out
@@ -1,46 +1,46 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       GeneratorExp         	prefix=|(|	suffix=|)|
-(3, 3)       GeneratorExp         	prefix=|(  |	suffix=|)|
-(5, 1)       GeneratorExp         	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(3, 3)       Name c               	prefix=||	suffix=|    |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(5, 1)       Name g               	prefix=||	suffix=| |
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     comprehension        	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 7)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 17)      Name c               	prefix=||	suffix=|    |
-(3, 26)      Name d               	prefix=||	suffix=|    |
-(3, 40)      Name e               	prefix=||	suffix=|  |
-(3, 46)      Name f               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 7)       Name g               	prefix=||	suffix=| |
-(5, 12)      Name h               	prefix=||	suffix=| |
-(5, 17)      Name i               	prefix=||	suffix=| |
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 28)      Name k               	prefix=||	suffix=| |
-(5, 33)      Name l               	prefix=||	suffix=| |
-(5, 39)      Name m               	prefix=||	suffix=| |
-(5, 44)      Name o               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(3, 3)       GeneratorExp         	prefix=|(  |	suffix=|)|	indent=||
+(5, 1)       GeneratorExp         	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(3, 3)       Name c               	prefix=||	suffix=|    |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(5, 1)       Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     comprehension        	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 7)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 17)      Name c               	prefix=||	suffix=|    |	indent=||
+(3, 26)      Name d               	prefix=||	suffix=|    |	indent=||
+(3, 40)      Name e               	prefix=||	suffix=|  |	indent=||
+(3, 46)      Name f               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 7)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name h               	prefix=||	suffix=| |	indent=||
+(5, 17)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 28)      Name k               	prefix=||	suffix=| |	indent=||
+(5, 33)      Name l               	prefix=||	suffix=| |	indent=||
+(5, 39)      Name m               	prefix=||	suffix=| |	indent=||
+(5, 44)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/global.out
+++ b/testdata/ast/golden/3.4/global.out
@@ -1,4 +1,4 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Global               	prefix=||	suffix=|\n|
-(3, 0)       Global               	prefix=|\n|	suffix=|\n|
-(5, 0)       Global               	prefix=|\n|	suffix=|\n|
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Global               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Global               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Global               	prefix=|\n|	suffix=|\n|	indent=||

--- a/testdata/ast/golden/3.4/if.out
+++ b/testdata/ast/golden/3.4/if.out
@@ -1,55 +1,55 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       If                   	prefix=||	suffix=||
-(4, 0)       If                   	prefix=|\n|	suffix=||
-(9, 0)       If                   	prefix=|\n|	suffix=||
-(18, 0)      If                   	prefix=|\n|	suffix=||
-(1, 3)       Name a               	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(4, 3)       Name c               	prefix=||	suffix=||
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(9, 3)       Name e               	prefix=||	suffix=||
-(10, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(11, 5)      If                   	prefix=||	suffix=||
-(18, 3)      Name m               	prefix=||	suffix=||
-(19, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(20, 5)      If                   	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(2, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 2)       Name e               	prefix=||	suffix=||
-(7, 2)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(10, 2)      Name g               	prefix=||	suffix=||
-(11, 5)      Name h               	prefix=||	suffix=||
-(12, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(13, 5)      If                   	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(19, 2)      Name n               	prefix=||	suffix=||
-(20, 5)      Name o               	prefix=||	suffix=||
-(21, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(23, 2)      If                   	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(12, 2)      Name i               	prefix=||	suffix=||
-(13, 5)      Name j               	prefix=||	suffix=||
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(21, 2)      Name p               	prefix=||	suffix=||
-(23, 5)      Name q               	prefix=||	suffix=||
-(24, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(14, 2)      Name k               	prefix=||	suffix=||
-(16, 2)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(24, 4)      Name r               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       If                   	prefix=||	suffix=||	indent=||
+(4, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(9, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(18, 0)      If                   	prefix=|\n|	suffix=||	indent=||
+(1, 3)       Name a               	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 3)       Name c               	prefix=||	suffix=||	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(9, 3)       Name e               	prefix=||	suffix=||	indent=||
+(10, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(11, 5)      If                   	prefix=||	suffix=||	indent=||
+(18, 3)      Name m               	prefix=||	suffix=||	indent=||
+(19, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(20, 5)      If                   	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(2, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 2)       Name e               	prefix=||	suffix=||	indent=|  |
+(7, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(10, 2)      Name g               	prefix=||	suffix=||	indent=|  |
+(11, 5)      Name h               	prefix=||	suffix=||	indent=||
+(12, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(13, 5)      If                   	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(19, 2)      Name n               	prefix=||	suffix=||	indent=|  |
+(20, 5)      Name o               	prefix=||	suffix=||	indent=||
+(21, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(23, 2)      If                   	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(12, 2)      Name i               	prefix=||	suffix=||	indent=|  |
+(13, 5)      Name j               	prefix=||	suffix=||	indent=||
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(16, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(21, 2)      Name p               	prefix=||	suffix=||	indent=|  |
+(23, 5)      Name q               	prefix=||	suffix=||	indent=|  |
+(24, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(14, 2)      Name k               	prefix=||	suffix=||	indent=|  |
+(16, 2)      Name l               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(24, 4)      Name r               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/ifexp.out
+++ b/testdata/ast/golden/3.4/ifexp.out
@@ -1,40 +1,40 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       IfExp                	prefix=||	suffix=||
-(3, 1)       IfExp                	prefix=|(|	suffix=|)|
-(5, 0)       IfExp                	prefix=||	suffix=||
-(7, 1)       IfExp                	prefix=|(|	suffix=|)|
-(1, 5)       Name b               	prefix=||	suffix=| |
-(1, 0)       Name a               	prefix=||	suffix=| |
-(1, 12)      Name c               	prefix=||	suffix=||
-(3, 11)      Name e               	prefix=|(|	suffix=|)|
-(3, 1)       Name d               	prefix=||	suffix=|   |
-(3, 22)      Name f               	prefix=||	suffix=| |
-(5, 5)       Name h               	prefix=||	suffix=| |
-(5, 0)       Name g               	prefix=||	suffix=| |
-(5, 12)      IfExp                	prefix=||	suffix=||
-(7, 9)       Name m               	prefix=||	suffix=| |
-(7, 2)       Tuple                	prefix=|(|	suffix=|)|
-(7, 16)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 17)      Name j               	prefix=||	suffix=| |
-(5, 12)      Name i               	prefix=||	suffix=| |
-(5, 24)      Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 2)       Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       IfExp                	prefix=||	suffix=||	indent=||
+(3, 1)       IfExp                	prefix=|(|	suffix=|)|	indent=||
+(5, 0)       IfExp                	prefix=||	suffix=||	indent=||
+(7, 1)       IfExp                	prefix=|(|	suffix=|)|	indent=||
+(1, 5)       Name b               	prefix=||	suffix=| |	indent=||
+(1, 0)       Name a               	prefix=||	suffix=| |	indent=||
+(1, 12)      Name c               	prefix=||	suffix=||	indent=||
+(3, 11)      Name e               	prefix=|(|	suffix=|)|	indent=||
+(3, 1)       Name d               	prefix=||	suffix=|   |	indent=||
+(3, 22)      Name f               	prefix=||	suffix=| |	indent=||
+(5, 5)       Name h               	prefix=||	suffix=| |	indent=||
+(5, 0)       Name g               	prefix=||	suffix=| |	indent=||
+(5, 12)      IfExp                	prefix=||	suffix=||	indent=||
+(7, 9)       Name m               	prefix=||	suffix=| |	indent=||
+(7, 2)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(7, 16)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 17)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 12)      Name i               	prefix=||	suffix=| |	indent=||
+(5, 24)      Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 2)       Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/import.out
+++ b/testdata/ast/golden/3.4/import.out
@@ -1,19 +1,19 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Import               	prefix=||	suffix=|\n|
-(3, 0)       Import               	prefix=|\n|	suffix=|\n|
-(5, 0)       Import               	prefix=|\n|	suffix=|\n|
-(7, 0)       Import               	prefix=|\n|	suffix=|\n|
-(9, 0)       Import               	prefix=|\n|	suffix=|\n|
-(11, 0)      Import               	prefix=|\n|	suffix=|\n|
-(-1, -1)     alias a              	prefix=||	suffix=||
-(-1, -1)     alias b              	prefix=||	suffix=||
-(-1, -1)     alias c              	prefix=||	suffix=||
-(-1, -1)     alias d              	prefix=||	suffix=||
-(-1, -1)     alias f              	prefix=||	suffix=||
-(-1, -1)     alias g              	prefix=||	suffix=||
-(-1, -1)     alias i              	prefix=||	suffix=||
-(-1, -1)     alias j              	prefix=||	suffix=||
-(-1, -1)     alias l              	prefix=||	suffix=||
-(-1, -1)     alias n              	prefix=||	suffix=||
-(-1, -1)     alias p.q.r          	prefix=||	suffix=||
-(-1, -1)     alias t.u.v          	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Import               	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Import               	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Import               	prefix=|\n|	suffix=|\n|	indent=||
+(-1, -1)     alias a              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias b              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias c              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias d              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias f              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias g              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias i              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias j              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias l              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias n              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias p.q.r          	prefix=||	suffix=||	indent=||
+(-1, -1)     alias t.u.v          	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/lambda.out
+++ b/testdata/ast/golden/3.4/lambda.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Lambda               	prefix=||	suffix=||
-(3, 0)       Lambda               	prefix=||	suffix=||
-(5, 0)       Lambda               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(1, 10)      Name b               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(3, 15)      Name f               	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 41)      Name o               	prefix=||	suffix=||
-(1, 7)       arg a                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 7)       arg c                	prefix=||	suffix=||
-(3, 10)      arg d                	prefix=||	suffix=||
-(3, 12)      Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 11)      arg g                	prefix=||	suffix=|  |
-(5, 15)      arg h                	prefix=||	suffix=||
-(5, 17)      arg i                	prefix=||	suffix=| |
-(5, 27)      arg k                	prefix=||	suffix=||
-(5, 32)      arg m                	prefix=||	suffix=| |
-(5, 38)      arg n                	prefix=||	suffix=||
-(5, 22)      Name j               	prefix=||	suffix=| |
-(5, 29)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(3, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(5, 0)       Lambda               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(1, 10)      Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(3, 15)      Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 41)      Name o               	prefix=||	suffix=||	indent=||
+(1, 7)       arg a                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 7)       arg c                	prefix=||	suffix=||	indent=||
+(3, 10)      arg d                	prefix=||	suffix=||	indent=||
+(3, 12)      Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 11)      arg g                	prefix=||	suffix=|  |	indent=||
+(5, 15)      arg h                	prefix=||	suffix=||	indent=||
+(5, 17)      arg i                	prefix=||	suffix=| |	indent=||
+(5, 27)      arg k                	prefix=||	suffix=||	indent=||
+(5, 32)      arg m                	prefix=||	suffix=| |	indent=||
+(5, 38)      arg n                	prefix=||	suffix=||	indent=||
+(5, 22)      Name j               	prefix=||	suffix=| |	indent=||
+(5, 29)      Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/list.out
+++ b/testdata/ast/golden/3.4/list.out
@@ -1,62 +1,62 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       List                 	prefix=||	suffix=||
-(3, 0)       List                 	prefix=||	suffix=||
-(5, 0)       List                 	prefix=||	suffix=||
-(7, 0)       List                 	prefix=||	suffix=||
-(9, 0)       List                 	prefix=||	suffix=||
-(13, 0)      List                 	prefix=||	suffix=||
-(15, 0)      List                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 3)       Name b               	prefix=||	suffix=||
-(1, 5)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 1)       Name e               	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=|  |
-(5, 10)      Name g               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 1)       Name h               	prefix=||	suffix=||
-(7, 4)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(13, 9)      Name m               	prefix=||	suffix=||
-(13, 13)     Tuple                	prefix=|(|	suffix=|)|
-(13, 18)     Name o               	prefix=||	suffix=||
-(13, 22)     Tuple                	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name r               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Name k               	prefix=||	suffix=||
-(13, 5)      Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 13)     Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 22)     Name p               	prefix=||	suffix=||
-(13, 25)     Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       List                 	prefix=||	suffix=||	indent=||
+(3, 0)       List                 	prefix=||	suffix=||	indent=||
+(5, 0)       List                 	prefix=||	suffix=||	indent=||
+(7, 0)       List                 	prefix=||	suffix=||	indent=||
+(9, 0)       List                 	prefix=||	suffix=||	indent=||
+(13, 0)      List                 	prefix=||	suffix=||	indent=||
+(15, 0)      List                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 3)       Name b               	prefix=||	suffix=||	indent=||
+(1, 5)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 1)       Name e               	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=|  |	indent=||
+(5, 10)      Name g               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 1)       Name h               	prefix=||	suffix=||	indent=||
+(7, 4)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 9)      Name m               	prefix=||	suffix=||	indent=||
+(13, 13)     Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 18)     Name o               	prefix=||	suffix=||	indent=||
+(13, 22)     Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name r               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Name k               	prefix=||	suffix=||	indent=||
+(13, 5)      Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 13)     Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 22)     Name p               	prefix=||	suffix=||	indent=||
+(13, 25)     Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/nonlocal.out
+++ b/testdata/ast/golden/3.4/nonlocal.out
@@ -1,7 +1,7 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(4, 0)       FunctionDef c        	prefix=|\n|	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Nonlocal             	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 2)       Nonlocal             	prefix=|  |	suffix=|\n|
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(4, 0)       FunctionDef c        	prefix=|\n|	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Nonlocal             	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 2)       Nonlocal             	prefix=|  |	suffix=|\n|	indent=|  |

--- a/testdata/ast/golden/3.4/num.out
+++ b/testdata/ast/golden/3.4/num.out
@@ -1,29 +1,29 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(21, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(23, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Num                  	prefix=||	suffix=||
-(3, 0)       Num                  	prefix=||	suffix=||
-(5, 0)       Num                  	prefix=||	suffix=||
-(7, 0)       Num                  	prefix=||	suffix=||
-(9, 1)       Num                  	prefix=|(|	suffix=|)|
-(11, 0)      Num                  	prefix=||	suffix=||
-(13, 0)      Num                  	prefix=||	suffix=||
-(15, 0)      Num                  	prefix=||	suffix=||
-(17, 0)      Num                  	prefix=||	suffix=||
-(19, 0)      UnaryOp              	prefix=||	suffix=||
-(21, 0)      Num                  	prefix=||	suffix=||
-(23, 0)      UnaryOp              	prefix=||	suffix=||
-(-1, -1)     USub                 	prefix=||	suffix=||
-(19, 1)      Num                  	prefix=||	suffix=||
-(-1, -1)     USub                 	prefix=||	suffix=||
-(23, 1)      Num                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(19, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(21, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(23, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Num                  	prefix=||	suffix=||	indent=||
+(3, 0)       Num                  	prefix=||	suffix=||	indent=||
+(5, 0)       Num                  	prefix=||	suffix=||	indent=||
+(7, 0)       Num                  	prefix=||	suffix=||	indent=||
+(9, 1)       Num                  	prefix=|(|	suffix=|)|	indent=||
+(11, 0)      Num                  	prefix=||	suffix=||	indent=||
+(13, 0)      Num                  	prefix=||	suffix=||	indent=||
+(15, 0)      Num                  	prefix=||	suffix=||	indent=||
+(17, 0)      Num                  	prefix=||	suffix=||	indent=||
+(19, 0)      UnaryOp              	prefix=||	suffix=||	indent=||
+(21, 0)      Num                  	prefix=||	suffix=||	indent=||
+(23, 0)      UnaryOp              	prefix=||	suffix=||	indent=||
+(-1, -1)     USub                 	prefix=||	suffix=||	indent=||
+(19, 1)      Num                  	prefix=||	suffix=||	indent=||
+(-1, -1)     USub                 	prefix=||	suffix=||	indent=||
+(23, 1)      Num                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/raise3.out
+++ b/testdata/ast/golden/3.4/raise3.out
@@ -1,29 +1,29 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Raise                	prefix=||	suffix=|\n|
-(3, 0)       Raise                	prefix=|\n|	suffix=|\n|
-(5, 0)       Try                  	prefix=|\n|	suffix=||
-(16, 0)      Raise                	prefix=|\n|	suffix=|\n|
-(1, 6)       Name a               	prefix=||	suffix=||
-(3, 7)       Name b               	prefix=||	suffix=||
-(6, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 0)       ExceptHandler        	prefix=||	suffix=||
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 6)      Name g               	prefix=||	suffix=|  |
-(16, 15)     Name h               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(6, 2)       Name c               	prefix=||	suffix=||
-(8, 2)       Try                  	prefix=|  |	suffix=||
-(12, 2)      Raise                	prefix=|  |	suffix=|\n|
-(14, 2)      Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 4)       Expr                 	prefix=|    |	suffix=|\n|
-(10, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 4)       Name d               	prefix=||	suffix=||
-(11, 4)      Raise                	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 10)     Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Raise                	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Raise                	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Try                  	prefix=|\n|	suffix=||	indent=||
+(16, 0)      Raise                	prefix=|\n|	suffix=|\n|	indent=||
+(1, 6)       Name a               	prefix=||	suffix=||	indent=||
+(3, 7)       Name b               	prefix=||	suffix=||	indent=||
+(6, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(7, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(16, 6)      Name g               	prefix=||	suffix=|  |	indent=||
+(16, 15)     Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(6, 2)       Name c               	prefix=||	suffix=||	indent=||
+(8, 2)       Try                  	prefix=|  |	suffix=||	indent=|  |
+(12, 2)      Raise                	prefix=|  |	suffix=|\n|	indent=|  |
+(14, 2)      Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 4)       Expr                 	prefix=|    |	suffix=|\n|	indent=|  |
+(10, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 4)       Name d               	prefix=||	suffix=||	indent=|  |
+(11, 4)      Raise                	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 10)     Name e               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/repr.out
+++ b/testdata/ast/golden/3.4/repr.out
@@ -1,13 +1,13 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Call                 	prefix=||	suffix=||
-(3, 0)       Call                 	prefix=||	suffix=||
-(1, 0)       Name repr            	prefix=||	suffix=||
-(1, 5)       Name a               	prefix=||	suffix=||
-(3, 0)       Name repr            	prefix=||	suffix=|  |
-(3, 9)       Name b               	prefix=||	suffix=|   |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Call                 	prefix=||	suffix=||	indent=||
+(3, 0)       Call                 	prefix=||	suffix=||	indent=||
+(1, 0)       Name repr            	prefix=||	suffix=||	indent=||
+(1, 5)       Name a               	prefix=||	suffix=||	indent=||
+(3, 0)       Name repr            	prefix=||	suffix=|  |	indent=||
+(3, 9)       Name b               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/sample.out
+++ b/testdata/ast/golden/3.4/sample.out
@@ -1,12 +1,14 @@
 (-1, -1)     Module               	prefix=||	suffix=||	indent=||
 (1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Call                 	prefix=||	suffix=||	indent=||
-(3, 0)       Call                 	prefix=||	suffix=||	indent=||
-(1, 0)       Name repr            	prefix=||	suffix=||	indent=||
+(1, 0)       Name foo             	prefix=||	suffix=||	indent=||
+(1, 4)       Compare              	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 5)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Eq                   	prefix=| |	suffix=| |	indent=||
+(1, 14)      Name c               	prefix=||	suffix=||	indent=||
 (1, 5)       Name a               	prefix=||	suffix=||	indent=||
-(3, 0)       Name repr            	prefix=||	suffix=|  |	indent=||
-(3, 9)       Name b               	prefix=||	suffix=|   |	indent=||
+(1, 8)       Name b               	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/semicolons.out
+++ b/testdata/ast/golden/3.4/semicolons.out
@@ -1,28 +1,28 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|;\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|;  \n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|;|
-(5, 7)       Expr                 	prefix=|   |	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|;|
-(7, 4)       Expr                 	prefix=|  |	suffix=|;\n|
-(9, 0)       If                   	prefix=|\n|	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(3, 0)       Name b               	prefix=||	suffix=| |
-(5, 0)       Name c               	prefix=||	suffix=|  |
-(5, 7)       Name d               	prefix=||	suffix=||
-(7, 0)       Name e               	prefix=||	suffix=||
-(7, 4)       Name f               	prefix=||	suffix=||
-(9, 3)       Name g               	prefix=||	suffix=||
-(9, 6)       Expr                 	prefix=||	suffix=|;|
-(9, 9)       Expr                 	prefix=| |	suffix=|;\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 6)       Name h               	prefix=||	suffix=||
-(9, 9)       Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|;\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|;  \n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|;|	indent=||
+(5, 7)       Expr                 	prefix=|   |	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|;|	indent=||
+(7, 4)       Expr                 	prefix=|  |	suffix=|;\n|	indent=||
+(9, 0)       If                   	prefix=|\n|	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(3, 0)       Name b               	prefix=||	suffix=| |	indent=||
+(5, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(5, 7)       Name d               	prefix=||	suffix=||	indent=||
+(7, 0)       Name e               	prefix=||	suffix=||	indent=||
+(7, 4)       Name f               	prefix=||	suffix=||	indent=||
+(9, 3)       Name g               	prefix=||	suffix=||	indent=||
+(9, 6)       Expr                 	prefix=||	suffix=|;|	indent=||
+(9, 9)       Expr                 	prefix=| |	suffix=|;\n|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 6)       Name h               	prefix=||	suffix=||	indent=||
+(9, 9)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/set.out
+++ b/testdata/ast/golden/3.4/set.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Set                  	prefix=||	suffix=||
-(3, 0)       Set                  	prefix=||	suffix=||
-(5, 0)       Set                  	prefix=||	suffix=||
-(7, 0)       Set                  	prefix=||	suffix=||
-(9, 0)       Set                  	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 3)       Name b               	prefix=||	suffix=||
-(1, 5)       Name c               	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=| |
-(5, 1)       Name e               	prefix=||	suffix=||
-(5, 6)       Name f               	prefix=||	suffix=|  |
-(5, 10)      Name g               	prefix=||	suffix=| |
-(7, 1)       Name h               	prefix=||	suffix=||
-(7, 4)       Name i               	prefix=||	suffix=||
-(9, 1)       Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Set                  	prefix=||	suffix=||	indent=||
+(3, 0)       Set                  	prefix=||	suffix=||	indent=||
+(5, 0)       Set                  	prefix=||	suffix=||	indent=||
+(7, 0)       Set                  	prefix=||	suffix=||	indent=||
+(9, 0)       Set                  	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 3)       Name b               	prefix=||	suffix=||	indent=||
+(1, 5)       Name c               	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=| |	indent=||
+(5, 1)       Name e               	prefix=||	suffix=||	indent=||
+(5, 6)       Name f               	prefix=||	suffix=|  |	indent=||
+(5, 10)      Name g               	prefix=||	suffix=| |	indent=||
+(7, 1)       Name h               	prefix=||	suffix=||	indent=||
+(7, 4)       Name i               	prefix=||	suffix=||	indent=||
+(9, 1)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/slice.out
+++ b/testdata/ast/golden/3.4/slice.out
@@ -1,53 +1,53 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Subscript            	prefix=||	suffix=||
-(3, 0)       Subscript            	prefix=||	suffix=||
-(5, 0)       Subscript            	prefix=||	suffix=||
-(7, 0)       Subscript            	prefix=||	suffix=||
-(9, 0)       Subscript            	prefix=||	suffix=||
-(11, 0)      Subscript            	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=|  |
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=| |
-(-1, -1)     ExtSlice             	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 0)       Name i               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name j               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 0)      Name k               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 6)       Name d               	prefix=||	suffix=||
-(3, 9)       Name e               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 4)       NameConstant         	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 5)      NameConstant         	prefix=|(|	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 5)       Name g               	prefix=||	suffix=|  |
-(5, 10)      Ellipsis             	prefix=||	suffix=||
-(5, 17)      Name h               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(3, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(5, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(7, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(9, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(11, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=| |	indent=||
+(-1, -1)     ExtSlice             	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 0)       Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name j               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 0)      Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 6)       Name d               	prefix=||	suffix=||	indent=||
+(3, 9)       Name e               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 4)       NameConstant         	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 5)      NameConstant         	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 5)       Name g               	prefix=||	suffix=|  |	indent=||
+(5, 10)      Ellipsis             	prefix=||	suffix=||	indent=||
+(5, 17)      Name h               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/str.out
+++ b/testdata/ast/golden/3.4/str.out
@@ -1,15 +1,15 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Str                  	prefix=||	suffix=||
-(3, 0)       Str                  	prefix=||	suffix=||
-(5, 0)       Str                  	prefix=||	suffix=||
-(7, 0)       Str                  	prefix=||	suffix=||
-(13, -1)     Str                  	prefix=||	suffix=||
-(15, 1)      Str                  	prefix=|(|	suffix=|)|
-(18, 0)      Str                  	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Str                  	prefix=||	suffix=||	indent=||
+(3, 0)       Str                  	prefix=||	suffix=||	indent=||
+(5, 0)       Str                  	prefix=||	suffix=||	indent=||
+(7, 0)       Str                  	prefix=||	suffix=||	indent=||
+(13, -1)     Str                  	prefix=||	suffix=||	indent=||
+(15, 1)      Str                  	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Str                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/subscript.out
+++ b/testdata/ast/golden/3.4/subscript.out
@@ -1,71 +1,71 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       Subscript            	prefix=||	suffix=||
-(3, 0)       Subscript            	prefix=||	suffix=||
-(5, 0)       Subscript            	prefix=||	suffix=||
-(7, 0)       Subscript            	prefix=||	suffix=||
-(9, 0)       Subscript            	prefix=||	suffix=||
-(11, 0)      Subscript            	prefix=||	suffix=||
-(13, 0)      Subscript            	prefix=||	suffix=||
-(15, 1)      Subscript            	prefix=||	suffix=||
-(1, 0)       Name a               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name f               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 0)       Name j               	prefix=||	suffix=|  |
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name l               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 0)      Name o               	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 0)      Name q               	prefix=||	suffix=||
-(-1, -1)     Slice                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name r               	prefix=|(|	suffix=|)|
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(1, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 2)       Name d               	prefix=||	suffix=||
-(3, 4)       Name e               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 3)       Name g               	prefix=||	suffix=|   |
-(5, 8)       Name h               	prefix=||	suffix=||
-(5, 11)      Name i               	prefix=||	suffix=| |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 4)       Name k               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 6)       Name m               	prefix=||	suffix=|  |
-(9, 11)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 3)      Name p               	prefix=||	suffix=|   |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 4)      Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(3, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(5, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(7, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(9, 0)       Subscript            	prefix=||	suffix=||	indent=||
+(11, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(13, 0)      Subscript            	prefix=||	suffix=||	indent=||
+(15, 1)      Subscript            	prefix=||	suffix=||	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name f               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 0)       Name j               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 0)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 0)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Slice                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name r               	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(1, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 2)       Name d               	prefix=||	suffix=||	indent=||
+(3, 4)       Name e               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 3)       Name g               	prefix=||	suffix=|   |	indent=||
+(5, 8)       Name h               	prefix=||	suffix=||	indent=||
+(5, 11)      Name i               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 4)       Name k               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 6)       Name m               	prefix=||	suffix=|  |	indent=||
+(9, 11)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 3)      Name p               	prefix=||	suffix=|   |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 4)      Name s               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/trailing_comments.out
+++ b/testdata/ast/golden/3.4/trailing_comments.out
@@ -1,31 +1,31 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|  # a\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|   #   b\n|
-(5, 0)       FunctionDef e        	prefix=|\n|	suffix=||
-(10, 0)      ClassDef i           	prefix=|\n|	suffix=||
-(15, 0)      Assign               	prefix=|\n|	suffix=|  # k\n|
-(1, 0)       Name a               	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=|( |	suffix=| )|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(8, 2)       Expr                 	prefix=|  |	suffix=|   # f\n|
-(5, 0)       Call                 	prefix=||	suffix=||
-(6, 1)       Name d               	prefix=||	suffix=||
-(13, 2)      Return               	prefix=|  |	suffix=|# j\n|
-(10, 1)      Name g               	prefix=||	suffix=||
-(11, 0)      Call                 	prefix=||	suffix=||
-(15, 0)      Name k               	prefix=||	suffix=| |
-(16, 2)      Name l               	prefix=|( # l prefix\n  |	suffix=|   #  l\n)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(8, 2)       Name f               	prefix=||	suffix=||
-(5, 1)       Name c               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 9)      Name j               	prefix=| |	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 1)      Name h               	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|  # a\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|   #   b\n|	indent=||
+(5, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      ClassDef i           	prefix=|\n|	suffix=||	indent=||
+(15, 0)      Assign               	prefix=|\n|	suffix=|  # k\n|	indent=||
+(1, 0)       Name a               	prefix=||	suffix=||	indent=||
+(3, 2)       Name b               	prefix=|( |	suffix=| )|	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|   # f\n|	indent=|  |
+(5, 0)       Call                 	prefix=||	suffix=||	indent=||
+(6, 1)       Name d               	prefix=||	suffix=||	indent=||
+(13, 2)      Return               	prefix=|  |	suffix=|# j\n|	indent=|  |
+(10, 1)      Name g               	prefix=||	suffix=||	indent=||
+(11, 0)      Call                 	prefix=||	suffix=||	indent=||
+(15, 0)      Name k               	prefix=||	suffix=| |	indent=||
+(16, 2)      Name l               	prefix=|( # l prefix\n  |	suffix=|   #  l\n)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(8, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(5, 1)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 9)      Name j               	prefix=| |	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 1)      Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/try.out
+++ b/testdata/ast/golden/3.4/try.out
@@ -1,86 +1,86 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Try                  	prefix=||	suffix=||
-(6, 0)       Try                  	prefix=|\n|	suffix=||
-(13, 0)      Try                  	prefix=|\n|	suffix=||
-(25, 0)      Try                  	prefix=|\n|	suffix=||
-(34, 0)      Try                  	prefix=|\n|	suffix=||
-(43, 0)      Try                  	prefix=|\n|	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(3, 0)       ExceptHandler        	prefix=||	suffix=||
-(7, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 0)       ExceptHandler e      	prefix=||	suffix=||
-(11, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(14, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(15, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(16, 0)      ExceptHandler k      	prefix=||	suffix=||
-(19, 0)      ExceptHandler        	prefix=||	suffix=||
-(22, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(23, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(27, 2)      Try                  	prefix=|  # 1\n  |	suffix=||
-(31, 0)      ExceptHandler        	prefix=||	suffix=||
-(36, 2)      Try                  	prefix=|  # 2\n  |	suffix=||
-(41, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(45, 2)      Try                  	prefix=|  # 3\n  |	suffix=||
-(50, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(2, 2)       Name a               	prefix=||	suffix=||
-(4, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(7, 2)       Name c               	prefix=||	suffix=||
-(8, 7)       Name d               	prefix=| |	suffix=| |
-(9, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(11, 2)      Name g               	prefix=||	suffix=||
-(14, 2)      Name h               	prefix=||	suffix=||
-(15, 2)      Name i               	prefix=||	suffix=||
-(16, 9)      Name j               	prefix=|   |	suffix=|   |
-(17, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(18, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(19, 8)      Name n               	prefix=|  |	suffix=||
-(20, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(22, 2)      Name p               	prefix=||	suffix=||
-(23, 2)      Name q               	prefix=||	suffix=||
-(28, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(29, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(32, 2)      Expr                 	prefix=|  |	suffix=|\n|
-(37, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(38, 2)      ExceptHandler        	prefix=|  |	suffix=||
-(41, 2)      Name w               	prefix=||	suffix=||
-(46, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(48, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(50, 2)      Name z               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(4, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 2)       Name f               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(17, 2)      Name l               	prefix=||	suffix=||
-(18, 2)      Name m               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(20, 2)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(28, 4)      Name r               	prefix=||	suffix=||
-(30, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(32, 2)      Name t               	prefix=||	suffix=||
-(37, 4)      Name u               	prefix=||	suffix=||
-(39, 4)      Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(46, 4)      Name x               	prefix=||	suffix=||
-(48, 4)      Name y               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(30, 4)      Name s               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(39, 4)      Name v               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Try                  	prefix=||	suffix=||	indent=||
+(6, 0)       Try                  	prefix=|\n|	suffix=||	indent=||
+(13, 0)      Try                  	prefix=|\n|	suffix=||	indent=||
+(25, 0)      Try                  	prefix=|\n|	suffix=||	indent=||
+(34, 0)      Try                  	prefix=|\n|	suffix=||	indent=||
+(43, 0)      Try                  	prefix=|\n|	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(3, 0)       ExceptHandler        	prefix=||	suffix=||	indent=||
+(7, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(8, 0)       ExceptHandler e      	prefix=||	suffix=||	indent=||
+(11, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(14, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(15, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=||
+(16, 0)      ExceptHandler k      	prefix=||	suffix=||	indent=||
+(19, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(22, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(23, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(27, 2)      Try                  	prefix=|  # 1\n  |	suffix=||	indent=||
+(31, 0)      ExceptHandler        	prefix=||	suffix=||	indent=||
+(36, 2)      Try                  	prefix=|  # 2\n  |	suffix=||	indent=||
+(41, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(45, 2)      Try                  	prefix=|  # 3\n  |	suffix=||	indent=||
+(50, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(2, 2)       Name a               	prefix=||	suffix=||	indent=||
+(4, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(7, 2)       Name c               	prefix=||	suffix=||	indent=||
+(8, 7)       Name d               	prefix=| |	suffix=| |	indent=||
+(9, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(11, 2)      Name g               	prefix=||	suffix=||	indent=|  |
+(14, 2)      Name h               	prefix=||	suffix=||	indent=||
+(15, 2)      Name i               	prefix=||	suffix=||	indent=||
+(16, 9)      Name j               	prefix=|   |	suffix=|   |	indent=||
+(17, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(18, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(19, 8)      Name n               	prefix=|  |	suffix=||	indent=||
+(20, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(22, 2)      Name p               	prefix=||	suffix=||	indent=|  |
+(23, 2)      Name q               	prefix=||	suffix=||	indent=|  |
+(28, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(29, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=||
+(32, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(37, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(38, 2)      ExceptHandler        	prefix=|  |	suffix=||	indent=||
+(41, 2)      Name w               	prefix=||	suffix=||	indent=|  |
+(46, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=||
+(48, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(50, 2)      Name z               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(4, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 2)       Name f               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(17, 2)      Name l               	prefix=||	suffix=||	indent=|  |
+(18, 2)      Name m               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(20, 2)      Name o               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(28, 4)      Name r               	prefix=||	suffix=||	indent=||
+(30, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(32, 2)      Name t               	prefix=||	suffix=||	indent=|  |
+(37, 4)      Name u               	prefix=||	suffix=||	indent=||
+(39, 4)      Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(46, 4)      Name x               	prefix=||	suffix=||	indent=||
+(48, 4)      Name y               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(30, 4)      Name s               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(39, 4)      Name v               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/tuple.out
+++ b/testdata/ast/golden/3.4/tuple.out
@@ -1,61 +1,61 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(9, 0)       Expr                 	prefix=|\n|	suffix=||
-(11, 0)      Expr                 	prefix=||	suffix=|\n|
-(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|
-(1, 1)       Tuple                	prefix=|(|	suffix=|)|
-(3, 0)       Tuple                	prefix=||	suffix=||
-(5, 0)       Tuple                	prefix=||	suffix=||
-(7, 2)       Tuple                	prefix=|( |	suffix=|)|
-(9, 0)       Tuple                	prefix=||	suffix=||
-(11, 1)      Tuple                	prefix=|(|	suffix=| )|
-(13, 1)      Tuple                	prefix=|(|	suffix=|)|
-(15, 1)      Tuple                	prefix=|(|	suffix=|)|
-(1, 1)       Name a               	prefix=||	suffix=||
-(1, 4)       Name b               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(3, 0)       Name c               	prefix=||	suffix=||
-(3, 3)       Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(5, 0)       Name e               	prefix=||	suffix=| |
-(5, 6)       Name f               	prefix=||	suffix=||
-(5, 8)       Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 2)       Name h               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(9, 0)       Name i               	prefix=||	suffix=|  |
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 1)      Name j               	prefix=||	suffix=||
-(11, 7)      Tuple                	prefix=|(  |	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Tuple                	prefix=|(|	suffix=|)|
-(13, 9)      Name o               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(15, 1)      Name p               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(11, 7)      Name k               	prefix=||	suffix=||
-(11, 10)     Name l               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(13, 2)      Name m               	prefix=||	suffix=||
-(13, 5)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(9, 0)       Expr                 	prefix=|\n|	suffix=||	indent=||
+(11, 0)      Expr                 	prefix=||	suffix=|\n|	indent=||
+(13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 1)       Tuple                	prefix=|(|	suffix=|)|	indent=||
+(3, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(5, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(7, 2)       Tuple                	prefix=|( |	suffix=|)|	indent=||
+(9, 0)       Tuple                	prefix=||	suffix=||	indent=||
+(11, 1)      Tuple                	prefix=|(|	suffix=| )|	indent=||
+(13, 1)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(15, 1)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(1, 4)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(3, 0)       Name c               	prefix=||	suffix=||	indent=||
+(3, 3)       Name d               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(5, 0)       Name e               	prefix=||	suffix=| |	indent=||
+(5, 6)       Name f               	prefix=||	suffix=||	indent=||
+(5, 8)       Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 2)       Name h               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(9, 0)       Name i               	prefix=||	suffix=|  |	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 1)      Name j               	prefix=||	suffix=||	indent=||
+(11, 7)      Tuple                	prefix=|(  |	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Tuple                	prefix=|(|	suffix=|)|	indent=||
+(13, 9)      Name o               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(15, 1)      Name p               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(11, 7)      Name k               	prefix=||	suffix=||	indent=||
+(11, 10)     Name l               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(13, 2)      Name m               	prefix=||	suffix=||	indent=||
+(13, 5)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/types.out
+++ b/testdata/ast/golden/3.4/types.out
@@ -1,67 +1,67 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       FunctionDef a        	prefix=||	suffix=||
-(4, 0)       FunctionDef e        	prefix=|\n|	suffix=||
-(7, 0)       FunctionDef l        	prefix=|\n|	suffix=||
-(10, 0)      FunctionDef r        	prefix=|\n|	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(2, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(5, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(4, 44)      Name bool            	prefix=||	suffix=||
-(-1, -1)     arguments            	prefix=||	suffix=||
-(8, 2)       Pass                 	prefix=|  |	suffix=|\n|
-(-1, -1)     arguments            	prefix=||	suffix=||
-(11, 2)      Pass                 	prefix=|  |	suffix=|\n|
-(1, 6)       arg b                	prefix=||	suffix=||
-(1, 9)       arg c                	prefix=||	suffix=||
-(1, 17)      arg d                	prefix=||	suffix=||
-(1, 24)      Num                  	prefix=||	suffix=||
-(4, 7)       arg f                	prefix=||	suffix=||
-(4, 23)      arg j                	prefix=||	suffix=||
-(4, 33)      arg k                	prefix=||	suffix=||
-(4, 19)      Name i               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 6)       arg m                	prefix=||	suffix=||
-(7, 22)      arg o                	prefix=||	suffix=||
-(10, 6)      arg s                	prefix=||	suffix=||
-(1, 12)      Name str             	prefix=||	suffix=||
-(1, 20)      Name int             	prefix=||	suffix=||
-(4, 11)      Attribute h          	prefix=||	suffix=| |
-(4, 26)      Name str             	prefix=||	suffix=||
-(4, 36)      Name int             	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 9)       Subscript            	prefix=||	suffix=||
-(7, 25)      Subscript            	prefix=||	suffix=||
-(10, 9)      Subscript            	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(4, 11)      Name g               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 9)       Name Optional        	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 25)      Name Tuple           	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(10, 9)      Name Tuple           	prefix=||	suffix=||
-(-1, -1)     Index                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 18)      Name n               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 31)      Tuple                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(10, 15)     Tuple                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(7, 31)      Name p               	prefix=||	suffix=||
-(7, 34)      Name q               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(10, 15)     Name t               	prefix=||	suffix=||
-(10, 18)     Ellipsis             	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
+(4, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef l        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      FunctionDef r        	prefix=|\n|	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(2, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(5, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(4, 44)      Name bool            	prefix=||	suffix=||	indent=||
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(11, 2)      Pass                 	prefix=|  |	suffix=|\n|	indent=|  |
+(1, 6)       arg b                	prefix=||	suffix=||	indent=||
+(1, 9)       arg c                	prefix=||	suffix=||	indent=||
+(1, 17)      arg d                	prefix=||	suffix=||	indent=||
+(1, 24)      Num                  	prefix=||	suffix=||	indent=||
+(4, 7)       arg f                	prefix=||	suffix=||	indent=||
+(4, 23)      arg j                	prefix=||	suffix=||	indent=||
+(4, 33)      arg k                	prefix=||	suffix=||	indent=||
+(4, 19)      Name i               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 6)       arg m                	prefix=||	suffix=||	indent=||
+(7, 22)      arg o                	prefix=||	suffix=||	indent=||
+(10, 6)      arg s                	prefix=||	suffix=||	indent=||
+(1, 12)      Name str             	prefix=||	suffix=||	indent=||
+(1, 20)      Name int             	prefix=||	suffix=||	indent=||
+(4, 11)      Attribute h          	prefix=||	suffix=| |	indent=||
+(4, 26)      Name str             	prefix=||	suffix=||	indent=||
+(4, 36)      Name int             	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 9)       Subscript            	prefix=||	suffix=||	indent=||
+(7, 25)      Subscript            	prefix=||	suffix=||	indent=||
+(10, 9)      Subscript            	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(4, 11)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 9)       Name Optional        	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 25)      Name Tuple           	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(10, 9)      Name Tuple           	prefix=||	suffix=||	indent=||
+(-1, -1)     Index                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 18)      Name n               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 31)      Tuple                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(10, 15)     Tuple                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(7, 31)      Name p               	prefix=||	suffix=||	indent=||
+(7, 34)      Name q               	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(10, 15)     Name t               	prefix=||	suffix=||	indent=||
+(10, 18)     Ellipsis             	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/unaryop.out
+++ b/testdata/ast/golden/3.4/unaryop.out
@@ -1,21 +1,21 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       Expr                 	prefix=||	suffix=|\n|
-(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|
-(1, 0)       UnaryOp              	prefix=||	suffix=||
-(3, 1)       UnaryOp              	prefix=|(|	suffix=|)|
-(5, 0)       UnaryOp              	prefix=||	suffix=||
-(7, 1)       UnaryOp              	prefix=|(|	suffix=|)|
-(-1, -1)     UAdd                 	prefix=||	suffix=||
-(1, 1)       Name a               	prefix=||	suffix=||
-(-1, -1)     USub                 	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=||	suffix=||
-(-1, -1)     Invert               	prefix=||	suffix=|  |
-(5, 3)       Name c               	prefix=||	suffix=||
-(-1, -1)     Not                  	prefix=||	suffix=| |
-(7, 7)       Name d               	prefix=|( |	suffix=|)|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       UnaryOp              	prefix=||	suffix=||	indent=||
+(3, 1)       UnaryOp              	prefix=|(|	suffix=|)|	indent=||
+(5, 0)       UnaryOp              	prefix=||	suffix=||	indent=||
+(7, 1)       UnaryOp              	prefix=|(|	suffix=|)|	indent=||
+(-1, -1)     UAdd                 	prefix=||	suffix=||	indent=||
+(1, 1)       Name a               	prefix=||	suffix=||	indent=||
+(-1, -1)     USub                 	prefix=||	suffix=||	indent=||
+(3, 2)       Name b               	prefix=||	suffix=||	indent=||
+(-1, -1)     Invert               	prefix=||	suffix=|  |	indent=||
+(5, 3)       Name c               	prefix=||	suffix=||	indent=||
+(-1, -1)     Not                  	prefix=||	suffix=| |	indent=||
+(7, 7)       Name d               	prefix=|( |	suffix=|)|	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/while.out
+++ b/testdata/ast/golden/3.4/while.out
@@ -1,17 +1,17 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       While                	prefix=||	suffix=||
-(5, 0)       While                	prefix=|\n|	suffix=||
-(1, 6)       NameConstant         	prefix=||	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(3, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(5, 6)       NameConstant         	prefix=||	suffix=||
-(6, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(8, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(2, 2)       Name a               	prefix=||	suffix=||
-(3, 2)       Name b               	prefix=||	suffix=||
-(6, 2)       Name c               	prefix=||	suffix=||
-(8, 2)       Name d               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       While                	prefix=||	suffix=||	indent=||
+(5, 0)       While                	prefix=|\n|	suffix=||	indent=||
+(1, 6)       NameConstant         	prefix=||	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(3, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(5, 6)       NameConstant         	prefix=||	suffix=||	indent=||
+(6, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(2, 2)       Name a               	prefix=||	suffix=||	indent=|  |
+(3, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(6, 2)       Name c               	prefix=||	suffix=||	indent=|  |
+(8, 2)       Name d               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/with.out
+++ b/testdata/ast/golden/3.4/with.out
@@ -1,35 +1,35 @@
-(-1, -1)     Module               	prefix=||	suffix=||
-(1, 0)       With                 	prefix=||	suffix=||
-(4, 0)       With                 	prefix=|\n|	suffix=||
-(7, 0)       With                 	prefix=|\n|	suffix=||
-(-1, -1)     withitem             	prefix=| |	suffix=||
-(2, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     withitem             	prefix=|    |	suffix=||
-(5, 2)       Expr                 	prefix=|  |	suffix=|\n|
-(-1, -1)     withitem             	prefix=| |	suffix=||
-(-1, -1)     withitem             	prefix=| |	suffix=||
-(8, 2)       With                 	prefix=|  |	suffix=||
-(1, 5)       Name a               	prefix=||	suffix=||
-(2, 2)       Name b               	prefix=||	suffix=||
-(4, 8)       Name c               	prefix=||	suffix=|   |
-(4, 18)      Name d               	prefix=||	suffix=|       |
-(5, 2)       Name e               	prefix=||	suffix=||
-(7, 5)       Name e               	prefix=||	suffix=||
-(7, 8)       Name f               	prefix=||	suffix=| |
-(7, 13)      Name g               	prefix=||	suffix=||
-(-1, -1)     withitem             	prefix=| |	suffix=||
-(9, 4)       Expr                 	prefix=|    |	suffix=|\n|
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(8, 7)       Name h               	prefix=||	suffix=| |
-(8, 12)      Name i               	prefix=||	suffix=||
-(9, 4)       Name j               	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
-(-1, -1)     Store                	prefix=||	suffix=||
-(-1, -1)     Load                 	prefix=||	suffix=||
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       With                 	prefix=||	suffix=||	indent=||
+(4, 0)       With                 	prefix=|\n|	suffix=||	indent=||
+(7, 0)       With                 	prefix=|\n|	suffix=||	indent=||
+(-1, -1)     withitem             	prefix=| |	suffix=||	indent=||
+(2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     withitem             	prefix=|    |	suffix=||	indent=||
+(5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     withitem             	prefix=| |	suffix=||	indent=||
+(-1, -1)     withitem             	prefix=| |	suffix=||	indent=||
+(8, 2)       With                 	prefix=|  |	suffix=||	indent=|  |
+(1, 5)       Name a               	prefix=||	suffix=||	indent=||
+(2, 2)       Name b               	prefix=||	suffix=||	indent=|  |
+(4, 8)       Name c               	prefix=||	suffix=|   |	indent=||
+(4, 18)      Name d               	prefix=||	suffix=|       |	indent=||
+(5, 2)       Name e               	prefix=||	suffix=||	indent=|  |
+(7, 5)       Name e               	prefix=||	suffix=||	indent=||
+(7, 8)       Name f               	prefix=||	suffix=| |	indent=||
+(7, 13)      Name g               	prefix=||	suffix=||	indent=||
+(-1, -1)     withitem             	prefix=| |	suffix=||	indent=|  |
+(9, 4)       Expr                 	prefix=|    |	suffix=|\n|	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(8, 7)       Name h               	prefix=||	suffix=| |	indent=|  |
+(8, 12)      Name i               	prefix=||	suffix=||	indent=|  |
+(9, 4)       Name j               	prefix=||	suffix=||	indent=|    |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Store                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||


### PR DESCRIPTION
This provides the necessary information to fix indentation when things
get moved around. E.g, if I want to move a node out of an "if" block to
the previous level, I need to know the indentation level of the outer
block and the indentation level of the inner statement so that the
prefixes can be corrected. The operations to make these corrections are
NOT included in this change, only the information is stored.

In addition, I'm changing how the block suffix is stored. Instead of
considering only one block suffix for a node, we'll store a block suffix
per suite that it contains. So, `If` nodes with an "else" else condition
will have a "block_suffix_body" and "block_suffix_orelse".

In a small related change, when retrieving formatting data,
`ast_utils.prop(node, attr)` will return `None` if the attribute is not
defined instead of an empty string.