### PR TITLE
Add the ability to lookup scopes created under the root scope

### DIFF
--- a/pasta/base/scope.py
+++ b/pasta/base/scope.py
@@ -186,10 +186,12 @@ class RootScope(Scope):
     return self
 
   def parent(self, node):
-    return self._parents[node]
+    return self._parents.get(node, None)
 
   def set_parent(self, node, parent):
     self._parents[node] = parent
+    if parent is None:
+      self._node_scopes[node] = self
 
   def get_name_for_node(self, node):
     return self._nodes_to_names.get(node, None)
@@ -203,7 +205,7 @@ class RootScope(Scope):
         return self._node_scopes[node]
       except KeyError:
         node = self.parent(node)
-    return self
+    return None
 
   def create_scope(self, parent_scope, node):
     self._node_scopes[node] = Scope(parent_scope)

--- a/pasta/base/scope_test.py
+++ b/pasta/base/scope_test.py
@@ -390,6 +390,8 @@ class ScopeTest(test_utils.TestCase):
     self.assertIs(class_node_scope.get_scope_for_node(func_node),
                   func_node_scope)
 
+    self.assertIsNone(sc.get_scope_for_node(ast.Name(id='foo')))
+
 
 def suite():
   result = unittest.TestSuite()

--- a/pasta/base/scope_test.py
+++ b/pasta/base/scope_test.py
@@ -358,6 +358,38 @@ class ScopeTest(test_utils.TestCase):
     self.assertItemsEqual(s.names['aaa'].attrs['bbb'].attrs['ccc'].reads,
                           [call3])
 
+  def test_get_scope_for_node(self):
+    src = textwrap.dedent("""\
+        import a
+        def b(c, d, e=1):
+          class F(d):
+            g = 1
+          return c
+        """)
+    t = ast.parse(src)
+    import_node, func_node = t.body
+    class_node, return_node = func_node.body
+
+    sc = scope.analyze(t)
+    import_node_scope = sc.get_scope_for_node(import_node)
+    self.assertIs(import_node_scope, sc)
+    self.assertItemsEqual(import_node_scope.names, ['a', 'b'])
+
+    func_node_scope = sc.get_scope_for_node(func_node)
+    self.assertIs(func_node_scope.parent_scope, sc)
+    self.assertItemsEqual(func_node_scope.names, ['c', 'd', 'e', 'F'])
+
+    class_node_scope = sc.get_scope_for_node(class_node)
+    self.assertIs(class_node_scope.parent_scope, func_node_scope)
+    self.assertItemsEqual(class_node_scope.names, ['g'])
+
+    return_node_scope = sc.get_scope_for_node(return_node)
+    self.assertIs(return_node_scope, func_node_scope)
+    self.assertItemsEqual(return_node_scope.names, ['c', 'd', 'e', 'F'])
+
+    self.assertIs(class_node_scope.get_scope_for_node(func_node),
+                  func_node_scope)
+
 
 def suite():
   result = unittest.TestSuite()


### PR DESCRIPTION
This will make it possible to do things like find out what arguments to a function are unused, and should help with determining whether non-top-level imports are used.