### PR TITLE
Refactor external_references in scope to be more useful

### DIFF
--- a/pasta/augment/rename.py
+++ b/pasta/augment/rename.py
@@ -66,9 +66,9 @@ def rename_external(t, old_name, new_name):
   has_changed = False
   renames = {}
   already_changed = []
-  for node in sc.external_references[old_name]:
-    if isinstance(node, ast.alias):
-      parent = sc.parent(node)
+  for ref in sc.external_references[old_name]:
+    if isinstance(ref.node, ast.alias):
+      parent = sc.parent(ref.node)
       # An alias may be the most specific reference to an imported name, but it
       # could if it is a child of an ImportFrom, the ImportFrom node's module
       # may also need to be updated.
@@ -77,15 +77,15 @@ def rename_external(t, old_name, new_name):
         renames[old_name.rsplit('.', 1)[-1]] = new_name.rsplit('.', 1)[-1]
         already_changed.append(parent)
       else:
-        node.name = new_name + node.name[len(old_name):]
-        if not node.asname:
+        ref.node.name = new_name + ref.node.name[len(old_name):]
+        if not ref.node.asname:
           renames[old_name] = new_name
       has_changed = True
-    elif isinstance(node, ast.ImportFrom):
-      if node not in already_changed:
-        assert _rename_name_in_importfrom(sc, node, old_name, new_name)
+    elif isinstance(ref.node, ast.ImportFrom):
+      if ref.node not in already_changed:
+        assert _rename_name_in_importfrom(sc, ref.node, old_name, new_name)
         renames[old_name.rsplit('.', 1)[-1]] = new_name.rsplit('.', 1)[-1]
-        already_changed.append(node)
+        already_changed.append(ref.node)
         has_changed = True
 
   for rename_old, rename_new in six.iteritems(renames):

--- a/pasta/base/scope_test.py
+++ b/pasta/base/scope_test.py
@@ -43,10 +43,11 @@ class ScopeTest(test_utils.TestCase):
 
     node_1_aaa = nodes[0].names[0]
     node_2_bbb = nodes[1].names[0]
-    node_2_ccc = nodes[1].names[1]
     node_2_ccc_ddd = nodes[1].names[1]
     node_3_aaa_bbb_ccc = nodes[2].names[0]
+    node_4_eee = nodes[3]
     node_4_fff = nodes[3].names[0]
+    node_5_ggg_hhh = nodes[4]
     node_5_iii = nodes[4].names[0]
     node_5_jjj = nodes[4].names[1]
 
@@ -61,39 +62,57 @@ class ScopeTest(test_utils.TestCase):
             'aaa', 'bbb', 'ccc', 'ccc.ddd', 'aaa.bbb', 'aaa.bbb.ccc', 'eee',
             'eee.fff', 'ggg', 'ggg.hhh', 'ggg.hhh.iii', 'ggg.hhh.jjj'
         })
-    self.assertItemsEqual(
-        s.external_references['aaa'],
-        [s.names['aaa'].definition] + s.names['aaa'].reads)
-    self.assertItemsEqual(
-        s.external_references['bbb'],
-        [s.names['bbb'].definition])
-    self.assertItemsEqual(
-        s.external_references['ccc.ddd'],
-        [s.names['ccc'].attrs['ddd'].definition])
-    self.assertItemsEqual(
-        s.external_references['aaa.bbb.ccc'],
-        [s.names['aaa'].attrs['bbb'].attrs['ccc'].definition])
-    self.assertItemsEqual(
-        s.external_references['eee.fff'], 
-        [s.names['fff'].definition])
-    self.assertItemsEqual(
-        s.external_references['ggg.hhh.iii'],
-        [s.names['iii'].definition])
-    self.assertItemsEqual(
-        s.external_references['ggg.hhh.jjj'],
-        [s.names['jjj'].definition])
+    self.assertItemsEqual(s.external_references['aaa'], [
+        scope.ExternalReference('aaa', node_1_aaa, s.names['aaa']),
+        scope.ExternalReference('aaa', node_3_aaa_bbb_ccc, s.names['aaa']),
+    ])
+    self.assertItemsEqual(s.external_references['bbb'], [
+        scope.ExternalReference('bbb', node_2_bbb, s.names['bbb']),
+    ])
+    self.assertItemsEqual(s.external_references['ccc'], [
+        scope.ExternalReference('ccc', node_2_ccc_ddd, s.names['ccc']),
+    ])
+    self.assertItemsEqual(s.external_references['ccc.ddd'], [
+        scope.ExternalReference('ccc.ddd', node_2_ccc_ddd,
+                                s.names['ccc'].attrs['ddd']),
+    ])
+    self.assertItemsEqual(s.external_references['aaa.bbb'], [
+        scope.ExternalReference('aaa.bbb', node_3_aaa_bbb_ccc,
+                                s.names['aaa'].attrs['bbb']),
+    ])
+    self.assertItemsEqual(s.external_references['aaa.bbb.ccc'], [
+        scope.ExternalReference('aaa.bbb.ccc', node_3_aaa_bbb_ccc,
+                                s.names['aaa'].attrs['bbb'].attrs['ccc']),
+    ])
+    self.assertItemsEqual(s.external_references['eee'], [
+        scope.ExternalReference('eee', node_4_eee, None),
+    ])
+    self.assertItemsEqual(s.external_references['eee.fff'], [
+        scope.ExternalReference('eee.fff', node_4_fff, s.names['fff']),
+    ])
+    self.assertItemsEqual(s.external_references['ggg'], [
+        scope.ExternalReference('ggg', node_5_ggg_hhh, None),
+    ])
+    self.assertItemsEqual(s.external_references['ggg.hhh'], [
+        scope.ExternalReference('ggg.hhh', node_5_ggg_hhh, None),
+    ])
+    self.assertItemsEqual(s.external_references['ggg.hhh.iii'], [
+        scope.ExternalReference('ggg.hhh.iii', node_5_iii, s.names['iii']),
+    ])
+    self.assertItemsEqual(s.external_references['ggg.hhh.jjj'], [
+        scope.ExternalReference('ggg.hhh.jjj', node_5_jjj, s.names['jjj']),
+    ])
     
-    self.assertEqual(s.names['aaa'].definition, node_1_aaa)
-    self.assertEqual(s.names['bbb'].definition, node_2_bbb)
-    self.assertEqual(s.names['ccc'].definition, node_2_ccc)
-    self.assertEqual(s.names['fff'].definition, node_4_fff)
-    self.assertEqual(s.names['iii'].definition, node_5_iii)
-    self.assertEqual(s.names['jjj'].definition, node_5_jjj)
+    self.assertIs(s.names['aaa'].definition, node_1_aaa)
+    self.assertIs(s.names['bbb'].definition, node_2_bbb)
+    self.assertIs(s.names['ccc'].definition, node_2_ccc_ddd)
+    self.assertIs(s.names['fff'].definition, node_4_fff)
+    self.assertIs(s.names['iii'].definition, node_5_iii)
+    self.assertIs(s.names['jjj'].definition, node_5_jjj)
 
     self.assertItemsEqual(s.names['aaa'].reads, [node_3_aaa_bbb_ccc])
     for ref in {'bbb', 'ccc', 'fff', 'iii', 'jjj'}:
-      self.assertEqual(s.names[ref].reads, [],
-                       'Expected no reads for %s' % ref)
+      self.assertEqual(s.names[ref].reads, [], 'Expected no reads for %s' % ref)
 
   def test_if_nested_imports(self):
     source = textwrap.dedent("""\


### PR DESCRIPTION
Previously external_references only gave the names mapped to the nodes
where they are referenced, but it's useful to have the Name reference as
well-- especially when the import is aliased.