### PR TITLE
Add asname to add_import

### DIFF
--- a/pasta/augment/import_utils.py
+++ b/pasta/augment/import_utils.py
@@ -90,17 +90,16 @@ def add_import(tree, name_to_import, asname=None, from_import=True, merge_from_i
 
     # Create a new node for this import
     import_node = ast.ImportFrom(module=from_module, names=[new_alias], level=0)
-    added_name = new_alias.asname or new_alias.name 
 
   # If not already created as an ImportFrom, create a normal Import node
   if not import_node:
+    new_alias = make_safe_alias_node(alias_name=name_to_import, asname=asname)
     import_node = ast.Import(
-        names=[make_safe_alias_node(alias_name=name_to_import, asname=asname)])
-    added_name = name_to_import
+        names=[new_alias])
 
   # Insert the node at the top of the module and return the name in scope
   tree.body.insert(1 if ast_utils.has_docstring(tree) else 0, import_node)
-  return added_name
+  return new_alias.asname or new_alias.name
 
 
 def split_import(sc, node, alias_to_remove):

--- a/pasta/augment/import_utils.py
+++ b/pasta/augment/import_utils.py
@@ -31,9 +31,12 @@ def add_import(tree, name_to_import, asname=None, from_import=True, merge_from_i
   """Adds an import to the module.
   
   This function will try to ensure not to create duplicate imports. If name_to_import is
-  already imported, it will return the existing import. If the import would create a name
-  that already exists in the scope given by tree, this function will "import as", and append
-  "_x" to the asname where x is the smallest positive integer generating a unique name.
+  already imported, it will return the existing import. This is true even if asname is set
+  (asname will be ignored, and the existing name will be returned).
+  
+  If the import would create a name that already exists in the scope given by tree, this
+  function will "import as", and append "_x" to the asname where x is the smallest positive
+  integer generating a unique name.
 
   Arguments:
     tree: (ast.Module) Module AST to modify.
@@ -50,7 +53,7 @@ def add_import(tree, name_to_import, asname=None, from_import=True, merge_from_i
   sc = scope.analyze(tree)
 
   # Don't add anything if it's already imported
-  if name_to_import in sc.external_references and asname is not None:
+  if name_to_import in sc.external_references:
     existing_ref = next((ref for ref in sc.external_references[name_to_import]
                          if ref.name_ref is not None), None)
     if existing_ref:

--- a/pasta/augment/import_utils_test.py
+++ b/pasta/augment/import_utils_test.py
@@ -239,17 +239,41 @@ class AddImportTest(test_utils.TestCase):
                      import_utils.add_import(tree, 'a.b.c', from_import=False))
     self.assertEqual('import a.b.c\n', pasta.dump(tree))
 
+  def test_add_normal_import_with_asname(self):
+    tree = ast.parse('')
+    self.assertEqual(
+      'd',
+      import_utils.add_import(tree, 'a.b.c', asname='d', from_import=False)
+    )
+    self.assertEqual('import a.b.c as d\n', pasta.dump(tree))
+    
   def test_add_from_import(self):
     tree = ast.parse('')
     self.assertEqual('c',
                      import_utils.add_import(tree, 'a.b.c', from_import=True))
     self.assertEqual('from a.b import c\n', pasta.dump(tree))
 
+  def test_add_from_import_with_asname(self):
+    tree = ast.parse('')
+    self.assertEqual(
+      'd',
+      import_utils.add_import(tree, 'a.b.c', asname='d', from_import=True)
+    )
+    self.assertEqual('from a.b import c as d\n', pasta.dump(tree))
+    
   def test_add_single_name_from_import(self):
     tree = ast.parse('')
     self.assertEqual('foo',
                      import_utils.add_import(tree, 'foo', from_import=True))
     self.assertEqual('import foo\n', pasta.dump(tree))
+
+  def test_add_single_name_from_import_with_asname(self):
+    tree = ast.parse('')
+    self.assertEqual(
+      'bar',
+      import_utils.add_import(tree, 'foo', asname='bar', from_import=True)
+    )
+    self.assertEqual('import foo as bar\n', pasta.dump(tree))
 
   def test_add_existing_import(self):
     tree = ast.parse('from a.b import c')
@@ -261,6 +285,11 @@ class AddImportTest(test_utils.TestCase):
     self.assertEqual('d', import_utils.add_import(tree, 'a.b.c'))
     self.assertEqual('from a.b import c as d\n', pasta.dump(tree))
 
+  def test_add_existing_import_aliased_with_asname(self):
+    tree = ast.parse('from a.b import c as d')
+    self.assertEqual('d', import_utils.add_import(tree, 'a.b.c', asname='e'))
+    self.assertEqual('from a.b import c as d\n', pasta.dump(tree))
+    
   def test_add_existing_import_normal_import(self):
     tree = ast.parse('import a.b.c')
     self.assertEqual('a.b',
@@ -281,6 +310,13 @@ class AddImportTest(test_utils.TestCase):
                      import_utils.add_import(tree, 'a.b.c', from_import=True))
     self.assertEqual(
         'from a.b import c as c_1\ndef c():\n  pass\n', pasta.dump(tree))
+
+  def test_add_import_with_asname_with_conflict(self):
+    tree = ast.parse('def c(): pass\n')
+    self.assertEqual('c_1',
+                     import_utils.add_import(tree, 'a.b', asname='c', from_import=True))
+    self.assertEqual(
+        'from a import b as c_1\ndef c():\n  pass\n', pasta.dump(tree))
 
   def test_merge_from_import(self):
     tree = ast.parse('from a.b import c')


### PR DESCRIPTION
This adds the ability to add imports with a given alias. If the import already exists with a different name, the asname is ignored. 