### PR TITLE
Add Bytes visitors for proper parsing of b'1' literals

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -1209,6 +1209,11 @@ class AstAnnotator(BaseVisitor):
     """Annotate a Str node with the exact string format."""
     self.attr(node, 'content', [self.tokens.str], deps=('s',), default=node.s)
 
+  @expression
+  def visit_Bytes(self, node):
+    """Annotate a Bytes node with the exact string format."""
+    self.attr(node, 'content', [self.tokens.str], deps=('s',), default=node.s)
+    
   @space_around
   def visit_Ellipsis(self, node):
     # Ellipsis is sometimes split into 3 tokens and other times a single token

--- a/pasta/base/codegen.py
+++ b/pasta/base/codegen.py
@@ -62,6 +62,12 @@ class Printer(annotate.BaseVisitor):
     self.code += content if content is not None else repr(node.s)
     self.suffix(node)
 
+  def visit_Bytes(self, node):
+    self.prefix(node)
+    content = fmt.get(node, 'content')
+    self.code += content if content is not None else repr(node.s)
+    self.suffix(node)
+
   def token(self, value):
     self.code += value
 

--- a/pasta/base/codegen_test.py
+++ b/pasta/base/codegen_test.py
@@ -81,6 +81,16 @@ class AutoFormatTest(with_metaclass(AutoFormatTestMeta, test_utils.TestCase)):
     t = ast.parse(src)
     self.assertEqual('exec(foo, bar)\n', pasta.dump(t))
 
+  def test_bytes(self):
+    src = "b'foo'"
+    t = ast.parse(src)
+    self.assertEqual("b'foo'\n", pasta.dump(t))
+
+  def test_re_str(self):
+    src = "r'foo'"
+    t = ast.parse(src)
+    self.assertEqual("r'foo'\n", pasta.dump(t))
+
 
 def suite():
   result = unittest.TestSuite()

--- a/pasta/base/codegen_test.py
+++ b/pasta/base/codegen_test.py
@@ -81,15 +81,11 @@ class AutoFormatTest(with_metaclass(AutoFormatTestMeta, test_utils.TestCase)):
     t = ast.parse(src)
     self.assertEqual('exec(foo, bar)\n', pasta.dump(t))
 
+  @test_utils.requires_features('bytes_node')
   def test_bytes(self):
     src = "b'foo'"
     t = ast.parse(src)
     self.assertEqual("b'foo'\n", pasta.dump(t))
-
-  def test_re_str(self):
-    src = "r'foo'"
-    t = ast.parse(src)
-    self.assertEqual("r'foo'\n", pasta.dump(t))
 
 
 def suite():

--- a/pasta/base/test_utils.py
+++ b/pasta/base/test_utils.py
@@ -66,6 +66,8 @@ def requires_features(*features):
 
 
 def supports_feature(feature):
+  if feature == 'bytes_node':
+    return hasattr(ast, 'Bytes') and issubclass(ast.Bytes, ast.AST)
   if feature == 'exec_node':
     return hasattr(ast, 'Exec') and issubclass(ast.Exec, ast.AST)
   if feature == 'type_annotations':

--- a/testdata/ast/bytes.in
+++ b/testdata/ast/bytes.in
@@ -17,5 +17,3 @@ n"""
 
 b'st' \
   b'uv'  b"wxyz"
-
-'zz' b'aa' "bb"

--- a/testdata/ast/bytes.in
+++ b/testdata/ast/bytes.in
@@ -1,0 +1,19 @@
+b"a"
+
+b'b'
+
+b"cd e"
+
+b"fg" b"hi"
+
+b"""jk
+l
+
+m
+n"""
+
+(b"op"
+ b"qr")
+
+b'st' \
+  b'uv'  b"wxyz"

--- a/testdata/ast/bytes.in
+++ b/testdata/ast/bytes.in
@@ -17,3 +17,5 @@ n"""
 
 b'st' \
   b'uv'  b"wxyz"
+
+'zz' b'aa' "bb"

--- a/testdata/ast/compare.in
+++ b/testdata/ast/compare.in
@@ -11,3 +11,7 @@ h  not in  j
 l   is m
 
 n  in o
+
+a == b
+
+a == b'1'

--- a/testdata/ast/compexps.in
+++ b/testdata/ast/compexps.in
@@ -11,5 +11,3 @@
 [g for g in h if i if j for k in l for m in o]
 
 ((p, q) for p, q in r)
-
-[a == b"1" for c in d]

--- a/testdata/ast/compexps.in
+++ b/testdata/ast/compexps.in
@@ -11,3 +11,5 @@
 [g for g in h if i if j for k in l for m in o]
 
 ((p, q) for p, q in r)
+
+[a == b"1" for c in d]

--- a/testdata/ast/golden/2.7/bytes.out
+++ b/testdata/ast/golden/2.7/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Str                  	prefix=||	suffix=||	indent=||
+(3, 0)       Str                  	prefix=||	suffix=||	indent=||
+(5, 0)       Str                  	prefix=||	suffix=||	indent=||
+(7, 0)       Str                  	prefix=||	suffix=||	indent=||
+(13, -1)     Str                  	prefix=||	suffix=||	indent=||
+(15, 1)      Str                  	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Str                  	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/2.7/compare.out
+++ b/testdata/ast/golden/2.7/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Str                  	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/bytes.out
+++ b/testdata/ast/golden/3.4/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/compare.out
+++ b/testdata/ast/golden/3.4/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/bytes.out
+++ b/testdata/ast/golden/3.5/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/compare.out
+++ b/testdata/ast/golden/3.5/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/bytes.out
+++ b/testdata/ast/golden/3.6/bytes.out
@@ -1,0 +1,15 @@
+(-1, -1)     Module               	prefix=||	suffix=||	indent=||
+(1, 0)       Expr                 	prefix=||	suffix=|\n|	indent=||
+(3, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(5, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(7, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(13, -1)     Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(18, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(1, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(3, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(5, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(7, 0)       Bytes                	prefix=||	suffix=||	indent=||
+(13, -1)     Bytes                	prefix=||	suffix=||	indent=||
+(15, 1)      Bytes                	prefix=|(|	suffix=|)|	indent=||
+(18, 0)      Bytes                	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/compare.out
+++ b/testdata/ast/golden/3.6/compare.out
@@ -6,6 +6,8 @@
 (9, 0)       Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      Expr                 	prefix=|\n|	suffix=|\n|	indent=||
 (1, 0)       Compare              	prefix=||	suffix=||	indent=||
 (3, 0)       Compare              	prefix=||	suffix=||	indent=||
 (5, 0)       Compare              	prefix=||	suffix=||	indent=||
@@ -13,6 +15,8 @@
 (9, 1)       Compare              	prefix=|(|	suffix=|)|	indent=||
 (11, 0)      Compare              	prefix=||	suffix=||	indent=||
 (13, 0)      Compare              	prefix=||	suffix=||	indent=||
+(15, 0)      Compare              	prefix=||	suffix=||	indent=||
+(17, 0)      Compare              	prefix=||	suffix=||	indent=||
 (1, 0)       Name a               	prefix=||	suffix=| |	indent=||
 (-1, -1)     Lt                   	prefix=||	suffix=||	indent=||
 (1, 4)       Name b               	prefix=||	suffix=||	indent=||
@@ -36,6 +40,15 @@
 (13, 0)      Name n               	prefix=||	suffix=|  |	indent=||
 (-1, -1)     In                   	prefix=||	suffix=||	indent=||
 (13, 6)      Name o               	prefix=||	suffix=||	indent=||
+(15, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(15, 5)      Name b               	prefix=||	suffix=||	indent=||
+(17, 0)      Name a               	prefix=||	suffix=| |	indent=||
+(-1, -1)     Eq                   	prefix=||	suffix=||	indent=||
+(17, 5)      Bytes                	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||


### PR DESCRIPTION
Py3 uses ast.Bytes nodes for b'xxx' literals. These visitors were missing, so Bytes nodes were silently dropped in (some) expressions (e.g. ListComp; in others, they were absorbed into prefix/suffix, I guess).

This adds the required visitors and some test cases that lead to errors without these visitors.

The goldens have not been regenerated.