### PR TITLE
Bugfix to accomodate python3 tokenization of FromImport level

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -190,6 +190,10 @@ class BaseVisitor(ast.NodeVisitor):
     """
     return ''
 
+  def dots(self, num_dots):
+    """Account for a number of dots."""
+    return '.' * num_dots
+
   def ws_oneline(self):
     """Account for up to one line of whitespace."""
     return self.ws(max_lines=1)
@@ -597,7 +601,9 @@ class BaseVisitor(ast.NodeVisitor):
     self.token('from')
     self.attr(node, 'module_prefix', [self.ws], default=' ')
 
-    module_pattern = ['.', self.ws] * node.level
+    module_pattern = []
+    if node.level > 0:
+      module_pattern.extend([self.dots(node.level), self.ws])
     if node.module:
       parts = node.module.split('.')
       for part in parts[:-1]:
@@ -1264,6 +1270,12 @@ class AstAnnotator(BaseVisitor):
         result += self.tokens.whitespace(max_lines=1)
       return result
     return self.tokens.whitespace(max_lines=max_lines, comment=comment)
+
+  def dots(self, num_dots):
+    """Parse a number of dots."""
+    def _parse_dots():
+      return self.tokens.dots(num_dots)
+    return _parse_dots
 
   def block_suffix(self, node, indent_level):
     fmt.set(node, 'suffix', self.tokens.block_whitespace(indent_level))

--- a/pasta/base/token_generator.py
+++ b/pasta/base/token_generator.py
@@ -172,6 +172,24 @@ class TokenGenerator(object):
     self._loc = self._tokens[self._i].end
     return ''.join(lines)
 
+  def dots(self, num_dots):
+    """Parse a number of dots.
+    
+    This is to work around an oddity in python3's tokenizer, which treats three
+    `.` tokens next to each other in a FromImport's level as an ellipsis. This
+    parses until the expected number of dots have been seen.
+    """
+    result = ''
+    dots_seen = 0
+    prev_loc = self._loc
+    while dots_seen < num_dots:
+      tok = self.next()
+      assert tok.src in ('.', '...')
+      result += self._space_between(prev_loc, tok) + tok.src
+      dots_seen += tok.src.count('.')
+      prev_loc = self._loc
+    return result
+
   def open_scope(self, node, single_paren=False):
     """Open a parenthesized scope on the given node."""
     result = ''

--- a/testdata/ast/fromimport.in
+++ b/testdata/ast/fromimport.in
@@ -11,3 +11,7 @@ from ..import l
 from m import(n)
 
 from o import (p,)
+
+from .... ... . import q
+
+from....import s

--- a/testdata/ast/golden/2.7/fromimport.out
+++ b/testdata/ast/golden/2.7/fromimport.out
@@ -6,6 +6,8 @@
 (9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (-1, -1)     alias b              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias d              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias f              	prefix=||	suffix=||	indent=||
@@ -13,3 +15,5 @@
 (-1, -1)     alias l              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias n              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias p              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias q              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias s              	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.4/fromimport.out
+++ b/testdata/ast/golden/3.4/fromimport.out
@@ -6,6 +6,8 @@
 (9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (-1, -1)     alias b              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias d              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias f              	prefix=||	suffix=||	indent=||
@@ -13,3 +15,5 @@
 (-1, -1)     alias l              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias n              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias p              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias q              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias s              	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/fromimport.out
+++ b/testdata/ast/golden/3.5/fromimport.out
@@ -6,6 +6,8 @@
 (9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (-1, -1)     alias b              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias d              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias f              	prefix=||	suffix=||	indent=||
@@ -13,3 +15,5 @@
 (-1, -1)     alias l              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias n              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias p              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias q              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias s              	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/fromimport.out
+++ b/testdata/ast/golden/3.6/fromimport.out
@@ -6,6 +6,8 @@
 (9, 0)       ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (11, 0)      ImportFrom m         	prefix=|\n|	suffix=|\n|	indent=||
 (13, 0)      ImportFrom o         	prefix=|\n|	suffix=|\n|	indent=||
+(15, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
+(17, 0)      ImportFrom           	prefix=|\n|	suffix=|\n|	indent=||
 (-1, -1)     alias b              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias d              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias f              	prefix=||	suffix=||	indent=||
@@ -13,3 +15,5 @@
 (-1, -1)     alias l              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias n              	prefix=||	suffix=||	indent=||
 (-1, -1)     alias p              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias q              	prefix=||	suffix=||	indent=||
+(-1, -1)     alias s              	prefix=||	suffix=||	indent=||


### PR DESCRIPTION
Fixes #56.

The bug is illustrated here (python3):
```
>>> list(t[1] for t in tokenize.generate_tokens(StringIO('from ... foo import bar').readline))
['from', '...', 'foo', 'import', 'bar', '']
>>> list(t[1] for t in tokenize.generate_tokens(StringIO('from .... foo import bar').readline))
['from', '...', '.', 'foo', 'import', 'bar', '']
>>> list(t[1] for t in tokenize.generate_tokens(StringIO('from ..... foo import bar').readline))
['from', '...', '.', '.', 'foo', 'import', 'bar', '']
>>> list(t[1] for t in tokenize.generate_tokens(StringIO('from ...... foo import bar').readline))
['from', '...', '...', 'foo', 'import', 'bar', '']
```

Python2 always splits the `.` into separate tokens.