### PR TITLE
Handle naked * in function definitions

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -1078,6 +1078,11 @@ class BaseVisitor(ast.NodeVisitor):
       arg_i += 1
       if arg_i < total_args:
         self.token(',')
+    elif kwonlyargs:
+      # If no vararg, but we have kwonlyargs, insert a naked *, which will
+      # definitely not be the last arg.
+      self.token('*')
+      self.token(',')
 
     for i, (arg, default) in enumerate(zip(kwonlyargs, kw_defaults)):
       self.visit(arg)

--- a/testdata/ast/functiondef3.in
+++ b/testdata/ast/functiondef3.in
@@ -3,3 +3,9 @@ def a(*b, c=0):
 
 def e(*f, g):
   h
+
+def i(*, k=l):
+  m
+
+def s(*, u):
+  v

--- a/testdata/ast/golden/3.4/functiondef3.out
+++ b/testdata/ast/golden/3.4/functiondef3.out
@@ -1,10 +1,16 @@
 (-1, -1)     Module               	prefix=||	suffix=||	indent=||
 (1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
 (4, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef i        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      FunctionDef s        	prefix=|\n|	suffix=||	indent=||
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(11, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (1, 7)       arg b                	prefix=||	suffix=||	indent=||
 (1, 10)      arg c                	prefix=| |	suffix=||	indent=||
 (1, 12)      Num                  	prefix=||	suffix=||	indent=||
@@ -12,5 +18,13 @@
 (4, 7)       arg f                	prefix=||	suffix=||	indent=||
 (4, 10)      arg g                	prefix=| |	suffix=||	indent=||
 (5, 2)       Name h               	prefix=||	suffix=||	indent=|  |
+(7, 9)       arg k                	prefix=| |	suffix=||	indent=||
+(7, 11)      Name l               	prefix=||	suffix=||	indent=||
+(8, 2)       Name m               	prefix=||	suffix=||	indent=|  |
+(10, 9)      arg u                	prefix=| |	suffix=||	indent=||
+(11, 2)      Name v               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.5/functiondef3.out
+++ b/testdata/ast/golden/3.5/functiondef3.out
@@ -1,10 +1,16 @@
 (-1, -1)     Module               	prefix=||	suffix=||	indent=||
 (1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
 (4, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef i        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      FunctionDef s        	prefix=|\n|	suffix=||	indent=||
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(11, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (1, 7)       arg b                	prefix=||	suffix=||	indent=||
 (1, 10)      arg c                	prefix=| |	suffix=||	indent=||
 (1, 12)      Num                  	prefix=||	suffix=||	indent=||
@@ -12,5 +18,13 @@
 (4, 7)       arg f                	prefix=||	suffix=||	indent=||
 (4, 10)      arg g                	prefix=| |	suffix=||	indent=||
 (5, 2)       Name h               	prefix=||	suffix=||	indent=|  |
+(7, 9)       arg k                	prefix=| |	suffix=||	indent=||
+(7, 11)      Name l               	prefix=||	suffix=||	indent=||
+(8, 2)       Name m               	prefix=||	suffix=||	indent=|  |
+(10, 9)      arg u                	prefix=| |	suffix=||	indent=||
+(11, 2)      Name v               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||

--- a/testdata/ast/golden/3.6/functiondef3.out
+++ b/testdata/ast/golden/3.6/functiondef3.out
@@ -1,10 +1,16 @@
 (-1, -1)     Module               	prefix=||	suffix=||	indent=||
 (1, 0)       FunctionDef a        	prefix=||	suffix=||	indent=||
 (4, 0)       FunctionDef e        	prefix=|\n|	suffix=||	indent=||
+(7, 0)       FunctionDef i        	prefix=|\n|	suffix=||	indent=||
+(10, 0)      FunctionDef s        	prefix=|\n|	suffix=||	indent=||
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (2, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (-1, -1)     arguments            	prefix=||	suffix=||	indent=||
 (5, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(8, 2)       Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
+(-1, -1)     arguments            	prefix=||	suffix=||	indent=||
+(11, 2)      Expr                 	prefix=|  |	suffix=|\n|	indent=|  |
 (1, 7)       arg b                	prefix=||	suffix=||	indent=||
 (1, 10)      arg c                	prefix=| |	suffix=||	indent=||
 (1, 12)      Num                  	prefix=||	suffix=||	indent=||
@@ -12,5 +18,13 @@
 (4, 7)       arg f                	prefix=||	suffix=||	indent=||
 (4, 10)      arg g                	prefix=| |	suffix=||	indent=||
 (5, 2)       Name h               	prefix=||	suffix=||	indent=|  |
+(7, 9)       arg k                	prefix=| |	suffix=||	indent=||
+(7, 11)      Name l               	prefix=||	suffix=||	indent=||
+(8, 2)       Name m               	prefix=||	suffix=||	indent=|  |
+(10, 9)      arg u                	prefix=| |	suffix=||	indent=||
+(11, 2)      Name v               	prefix=||	suffix=||	indent=|  |
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
+(-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||
 (-1, -1)     Load                 	prefix=||	suffix=||	indent=||


### PR DESCRIPTION
This enables the Py3 syntax:

```
def a(b, *, c):
  pass
```

and

```
def a(b, *, c=d):
  pass
```