### PR TITLE
Add python 2/3 trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,11 @@ setup(
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "License :: OSI Approved :: Apache Software License",
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
Clearly identify this project as supporting python 2 and 3.
This is useful for utility programs like [caniusepython3](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3).