### PR TITLE
Fix error in end_{line,col} tracking

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -1401,8 +1401,8 @@ def get_ast_annotator(astlib=ast):
         fmt.set(node, 'start_line', self.tokens.peek().start[0])
         fmt.set(node, 'start_col', self.tokens.peek().start[1])
         super(AstAnnotator, self).visit(node)
-        fmt.set(node, 'end_line', self.tokens.peek().end[0])
-        fmt.set(node, 'end_col', self.tokens.peek().end[1])
+        fmt.set(node, 'end_line', self.tokens.peek().start[0])
+        fmt.set(node, 'end_col', self.tokens.peek().start[1])
       except (TypeError, ValueError, IndexError, KeyError) as e:
         raise AnnotationError(e)
 

--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -608,7 +608,8 @@ bar('x')
 
     self.assertEqual(2, fmt.get(a, 'end_col'))
     self.assertEqual(6, fmt.get(b, 'end_col'))
-    self.assertEqual(9, fmt.get(c, 'end_col'))
+    # NB: 0 to support python2.7, which does not generate a NEWLINE token.
+    self.assertIn(fmt.get(c, 'end_col'), (9, 0))
 
 
 def _get_diff(before, after):

--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -589,15 +589,26 @@ bar('x')
     self.assertEqual(1, fmt.get(foo, 'start_line'))
     self.assertEqual(0, fmt.get(foo, 'start_col'))
     self.assertEqual(2, fmt.get(foo, 'end_line'))
-    self.assertEqual(13, fmt.get(foo, 'end_col'))
+    self.assertEqual(12, fmt.get(foo, 'end_col'))
     self.assertEqual(2, fmt.get(bar_arg, 'start_line'))
     self.assertEqual(2, fmt.get(bar_arg, 'start_col'))
     self.assertEqual(2, fmt.get(bar_arg, 'end_line'))
-    self.assertEqual(12, fmt.get(bar_arg, 'end_col'))
+    self.assertEqual(11, fmt.get(bar_arg, 'end_col'))
     self.assertEqual(3, fmt.get(bar, 'start_line'))
     self.assertEqual(0, fmt.get(bar, 'start_col'))
     self.assertEqual(3, fmt.get(bar, 'end_line'))
-    self.assertEqual(9, fmt.get(bar, 'end_col'))
+    self.assertEqual(8, fmt.get(bar, 'end_col'))
+
+  def test_end_col(self):
+    src = 'a = b + c'
+    t = pasta.parse(src, astlib=astlib)
+    name_nodes = ast_utils.find_nodes_by_type(t, astlib.Name, astlib=astlib)
+    name_nodes.sort(key=lambda node: node.col_offset)
+    a, b, c = name_nodes
+
+    self.assertEqual(2, fmt.get(a, 'end_col'))
+    self.assertEqual(6, fmt.get(b, 'end_col'))
+    self.assertEqual(9, fmt.get(c, 'end_col'))
 
 
 def _get_diff(before, after):


### PR DESCRIPTION
The current implementation sets the end line and column of a node to the end values for the next token after visiting that node.  However, since visiting a node consumes all of its tokens, this sets them to the end of the first token outside the node.  This makes it seem like the node contains the token after it.

For example, in the test added in this commit for "a = b + c", the current implementation has a's end_col as 3 and b's as 7, which means a contains the "=" and b contains the "+".

This commit fixes the issue by setting the end values to the start values for the next token.