### PR TITLE
Fix bug where scope was not visiting keyword only arguments.

### DIFF
--- a/pasta/base/scope.py
+++ b/pasta/base/scope.py
@@ -145,7 +145,7 @@ def analyze(tree, astlib=ast):
           self.scope.define_name(arg_name, node)
       else:
         # Visit defaults first to avoid declarations in args
-        self.visit_in_order(node, 'vararg', 'kwarg')
+        self.visit_in_order(node, 'vararg', 'kw_defaults', 'kwonlyargs', 'kwarg')
 
     def visit_arg(self, node):
       self.scope.define_name(node.arg, node)

--- a/pasta/base/scope_test.py
+++ b/pasta/base/scope_test.py
@@ -485,6 +485,27 @@ class ScopeTest(test_utils.TestCase):
     self.assertIn('ddd', func_scope.names)
     self.assertItemsEqual(func_scope.names['ddd'].reads, [ddd_expr.value])
 
+  def test_keyword_only_arguments_and_defaults(self):
+    source = textwrap.dedent("""\
+        def aaa(bbb, *, ccc, ddd=eee):
+          ccc
+          ddd
+        fff(ccc, ddd)
+        """)
+    tree = astlib.parse(source)
+    funcdef, call = tree.body
+    argval = funcdef.args.kw_defaults[1]
+    ccc_expr, ddd_expr = funcdef.body
+
+    sc = scope.analyze(tree, astlib=astlib)
+
+    func_scope = sc.lookup_scope(funcdef)
+    self.assertIn('ccc', func_scope.names)
+    self.assertItemsEqual(func_scope.names['ccc'].reads, [ccc_expr.value])
+    self.assertIn('ddd', func_scope.names)
+    self.assertItemsEqual(func_scope.names['ddd'].reads, [ddd_expr.value])
+    self.assertItemsEqual(sc.names['eee'].reads, [argval])
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This adds keyword only arguments and their defaults (PEP 3102) to the scope.