### PR TITLE
Only run the new scope test for keyword only arguments when supported.

### DIFF
--- a/pasta/base/scope_test.py
+++ b/pasta/base/scope_test.py
@@ -485,6 +485,7 @@ class ScopeTest(test_utils.TestCase):
     self.assertIn('ddd', func_scope.names)
     self.assertItemsEqual(func_scope.names['ddd'].reads, [ddd_expr.value])
 
+  @test_utils.requires_features(['keyword_only_arguments'], astlib=astlib)
   def test_keyword_only_arguments_and_defaults(self):
     source = textwrap.dedent("""\
         def aaa(bbb, *, ccc, ddd=eee):

--- a/pasta/base/test_utils.py
+++ b/pasta/base/test_utils.py
@@ -91,6 +91,8 @@ def supports_feature(feature, astlib=ast):
     return _try_to_parse('def a():	b\n       c', astlib)
   if feature == 'ur_str_literal':
     return _try_to_parse('ur""', astlib)
+  if feature == 'keyword_only_arguments':
+    return _try_to_parse('def a(b, *, c): pass', astlib)
   return False
 
 


### PR DESCRIPTION
This test was failing with Python 2.7.