### PR TITLE
Fix f-string debug format parsing for Python 3.8+  ({expr=})

### DIFF
--- a/pasta/base/annotate.py
+++ b/pasta/base/annotate.py
@@ -1265,10 +1265,13 @@ class BaseVisitor(ast.NodeVisitor):
   @fstring_expression
   def visit_FormattedValue(self, node):
     self.visit(node.value)
+    self.optional_token(node, 'debug_specifier', '=')
     if node.conversion != -1:
-      self.attr(node, 'conversion',
-                [self.ws, '!', chr(node.conversion)], deps=('conversion',),
-                default='!%c' % node.conversion)
+      self.optional_token(node, 'conversion_prefix', '!')
+      if fmt.get(node, 'conversion_prefix'):
+        self.attr(node, 'conversion_char',
+                  [chr(node.conversion)], deps=('conversion',),
+                  default='%c' % node.conversion)
     if node.format_spec:
       self.attr(node, 'format_spec_prefix', [self.ws, ':', self.ws],
                 default=':')

--- a/pasta/base/annotate_test.py
+++ b/pasta/base/annotate_test.py
@@ -454,6 +454,18 @@ class FstringTest(test_utils.TestCase):
         fmt.get(node, 'content'),
         'f"a {{{__pasta_fstring_val_0__} {{c}}"')
 
+  @test_utils.requires_features('fstring')
+  def test_fstring_debug_format(self):
+    src = 'f"{a=}"'
+    self.assertEqual(src, pasta.dump(pasta.parse(src)))
+    src = 'f"{a=!r}"'
+    self.assertEqual(src, pasta.dump(pasta.parse(src)))
+    src = 'f"{a=:d}"'
+    self.assertEqual(src, pasta.dump(pasta.parse(src)))
+    src = 'f"{a=!r:10}"'
+    self.assertEqual(src, pasta.dump(pasta.parse(src)))
+    src = 'f"prefix {x=} suffix"'
+    self.assertEqual(src, pasta.dump(pasta.parse(src)))
 
 
 class VersionSupportTest(test_utils.TestCase):


### PR DESCRIPTION
## Summary

This PR fixes Issue #115, where Python 3.8+ f-string debug format ({expr=}) fails to parse correctly and raises:

    AnnotationError: Expected '!' but found '='

The fix is scoped to Python 3.8–3.11, which are within pasta’s supported range.

---

## Background

Python 3.8 introduced debug f-strings:

    f"{a=}"

Unlike regular f-strings, {expr=}:
- Leaves '=' in the token stream
- Implicitly sets conversion=repr
- Does not include an explicit '!' in the source

The current logic in visit_FormattedValue assumes that conversion must be introduced by '!', which causes parsing to fail.

---

## Root Cause

When parsing {expr=}:
1. The expression tokens are consumed
2. The parser expects '!' for conversion
3. '=' is encountered instead
4. An error is raised

---

## Fix

The fix updates visit_FormattedValue to:

1. Explicitly consume the debug specifier '='
2. Make conversion parsing conditional on the presence of '!'
3. Only parse the conversion character when '!' is present

This matches CPython’s behavior.

---

## Tests

Added test_fstring_debug_format covering:
- f"{a=}"
- f"{a=!r}"
- f"{a=:d}"
- f"{a=!r:10}"
- f"prefix {x=} suffix"

---

## Verification

Tests pass on:
- Python 3.10
- Python 3.11

---

## Notes

Python 3.12+ introduces PEP 701 (PEG-based f-string parsing), which is a separate compatibility issue and not addressed here.
